### PR TITLE
Add Dashboard ECS Service

### DIFF
--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -32,6 +32,13 @@ resource "aws_ecr_repository" "iiif_builder" {
   }
 }
 
+resource "aws_ecr_repository" "dashboard" {
+  name = "iiif-builder-dashboard"
+  tags = {
+    Terraform = true
+  }
+}
+
 data "template_file" "public_key" {
   template = file("files/key.pub")
 }

--- a/infrastructure/common/outputs.tf
+++ b/infrastructure/common/outputs.tf
@@ -2,6 +2,10 @@ output "iiif_builder_url" {
   value = aws_ecr_repository.iiif_builder.repository_url
 }
 
+output "dashboard_url" {
+  value = aws_ecr_repository.dashboard.repository_url
+}
+
 output "staging_security_group_id" {
   value = aws_security_group.staging.id
 }

--- a/infrastructure/modules/ecs/outputs.tf
+++ b/infrastructure/modules/ecs/outputs.tf
@@ -1,0 +1,7 @@
+output "task_role_name" {
+  value = module.task_definition.task_role_name
+}
+
+output "task_role_arn" {
+  value = module.task_definition.task_role_arn
+}

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -129,3 +129,7 @@ module "dashboard" {
     AzureAd__ClientId                     = "iiif-builder/staging/azuread-clientid"
   }
 }
+
+data "aws_iam_role" "dashboard_task_role" {
+  name = module.dashboard.task_role_name
+}

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -11,7 +11,7 @@ module "load_balancer" {
     data.terraform_remote_state.common.outputs.staging_security_group_id,
   ]
 
-  certificate_domain = "dlcs.io"
+  certificate_domain = local.domain
 
   lb_controlled_ingress_cidrs = ["0.0.0.0/0"]
 }
@@ -36,7 +36,7 @@ module "rds" {
 }
 
 data "aws_route53_zone" "external" {
-  name = "dlcs.io"
+  name = local.domain
 }
 
 module "iiif-builder" {
@@ -64,8 +64,8 @@ module "iiif-builder" {
   lb_fqdn         = module.load_balancer.lb_dns_name
   #path_patterns     = ["/iiif/*"]
   listener_priority = 10
-  hostname          = "stage-iiif"
-  domain            = "dlcs.io"
+  hostname          = "iiif-stage"
+  domain            = local.domain
   zone_id           = data.aws_route53_zone.external.id
 
   port_mappings = [{

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -39,6 +39,12 @@ data "aws_route53_zone" "external" {
   name = local.domain
 }
 
+resource "aws_ecs_cluster" "iiif_builder" {
+  name = local.full_name
+  tags = local.common_tags
+}
+
+# main IIIF-Builder application
 module "iiif-builder" {
   source = "../modules/ecs"
 
@@ -80,7 +86,46 @@ module "iiif-builder" {
   }
 }
 
-resource "aws_ecs_cluster" "iiif_builder" {
-  name = local.full_name
-  tags = local.common_tags
+# dds-dashboard application
+module "dashboard" {
+  source = "../modules/ecs"
+
+  name        = "iiif-builder-dashboard"
+  environment = local.environment
+  vpc_id      = local.vpc_id
+
+  docker_image   = "${data.terraform_remote_state.common.outputs.dashboard_url}:staging"
+  container_port = 80
+
+  cpu    = 256
+  memory = 512
+
+  ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
+  service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
+  service_subnets                = local.vpc_private_subnets
+  service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
+
+  healthcheck_path = "/management/healthcheck"
+
+  lb_listener_arn = module.load_balancer.https_listener_arn
+  lb_zone_id      = module.load_balancer.lb_zone_id
+  lb_fqdn         = module.load_balancer.lb_dns_name
+
+  listener_priority = 20
+  hostname          = "dds-stage"
+  domain            = local.domain
+  zone_id           = data.aws_route53_zone.external.id
+
+  port_mappings = [{
+    containerPort = 80
+    hostPort      = 80
+    protocol      = "tcp"
+  }]
+
+  secret_env_vars = {
+    ConnectionStrings__Dds                = "iiif-builder/staging/ddsinstrumentation-connstr"
+    ConnectionStrings__DdsInstrumentation = "iiif-builder/staging/dds-connstr"
+    AzureAd__TenantId                     = "iiif-builder/staging/azuread-tenantid"
+    AzureAd__ClientId                     = "iiif-builder/staging/azuread-clientid"
+  }
 }

--- a/infrastructure/staging/output.tf
+++ b/infrastructure/staging/output.tf
@@ -1,0 +1,3 @@
+output "dashboard_role_id" {
+  value = data.aws_iam_role.dashboard_task_role.unique_id
+}

--- a/infrastructure/staging/variables.tf
+++ b/infrastructure/staging/variables.tf
@@ -13,6 +13,7 @@ locals {
     "Project"     = local.name
   }
 
+  # todo - take from remote state
   vpc_id = "vpc-0422549322a611c44"
   vpc_private_subnets = [
     "subnet-061cc8889c4af6419",
@@ -31,6 +32,8 @@ locals {
   ]
 
   account_id = data.aws_caller_identity.current.account_id
+
+  domain = "dlcs.io"
 }
 
 variable "region" {


### PR DESCRIPTION
Add dashboard fargate task, currently served under (dds-stage.dlcs.io).

Add new ECR repository for dashboard images.

Renamed hostname for iiif-builder (follow Wellcome default of `{name}-{stage}`)