### PR TITLE
Moved load_balancer module to common

### DIFF
--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -25,6 +25,24 @@ resource "aws_security_group" "staging" {
   }
 }
 
+module "load_balancer" {
+  source = "../modules/load_balancer"
+
+  name        = "iiif-builder"
+  environment = "stage"
+
+  public_subnets = local.vpc_public_subnets
+  vpc_id         = local.vpc_id
+
+  service_lb_security_group_ids = [
+    aws_security_group.staging.id,
+  ]
+
+  certificate_domain = "dlcs.io"
+
+  lb_controlled_ingress_cidrs = ["0.0.0.0/0"]
+}
+
 resource "aws_ecr_repository" "iiif_builder" {
   name = "iiif-builder"
   tags = {

--- a/infrastructure/common/outputs.tf
+++ b/infrastructure/common/outputs.tf
@@ -25,3 +25,15 @@ output "service_discovery_namespace_id" {
 output "service_discovery_namespace_arn" {
   value = aws_service_discovery_private_dns_namespace.iiif_builder.arn
 }
+
+output "lb_listener_arn" {
+  value = module.load_balancer.https_listener_arn
+}
+
+output "lb_zone_id"{
+  value = module.load_balancer.lb_zone_id
+}
+
+output "lb_fqdn"{ 
+  value = module.load_balancer.lb_dns_name
+}

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -19,9 +19,9 @@ module "dashboard" {
 
   healthcheck_path = "/management/healthcheck"
 
-  lb_listener_arn = module.load_balancer.https_listener_arn
-  lb_zone_id      = module.load_balancer.lb_zone_id
-  lb_fqdn         = module.load_balancer.lb_dns_name
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
+  lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 20
   hostname          = "dds-stage"
@@ -100,9 +100,9 @@ module "dashboard_stageprod" {
 
   healthcheck_path = "/management/healthcheck"
 
-  lb_listener_arn = module.load_balancer.https_listener_arn
-  lb_zone_id      = module.load_balancer.lb_zone_id
-  lb_fqdn         = module.load_balancer.lb_dns_name
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
+  lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 60
   hostname          = "dds-stageprd"

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -19,9 +19,10 @@ module "iiif_builder" {
 
   healthcheck_path = "/management/healthcheck"
 
-  lb_listener_arn   = module.load_balancer.https_listener_arn
-  lb_zone_id        = module.load_balancer.lb_zone_id
-  lb_fqdn           = module.load_balancer.lb_dns_name
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
+  lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
+
   listener_priority = 10
   hostname          = "iiif-stage"
   domain            = local.domain
@@ -64,9 +65,10 @@ module "iiif_builder_stageprod" {
 
   healthcheck_path = "/management/healthcheck"
 
-  lb_listener_arn   = module.load_balancer.https_listener_arn
-  lb_zone_id        = module.load_balancer.lb_zone_id
-  lb_fqdn           = module.load_balancer.lb_dns_name
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
+  lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
+
   listener_priority = 50
   hostname          = "iiif-stageprd"
   domain            = local.domain

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -1,21 +1,3 @@
-module "load_balancer" {
-  source = "../modules/load_balancer"
-
-  name        = local.name
-  environment = local.environment
-
-  public_subnets = local.vpc_public_subnets
-  vpc_id         = local.vpc_id
-
-  service_lb_security_group_ids = [
-    data.terraform_remote_state.common.outputs.staging_security_group_id,
-  ]
-
-  certificate_domain = local.domain
-
-  lb_controlled_ingress_cidrs = ["0.0.0.0/0"]
-}
-
 module "rds" {
   source = "../modules/rds"
 


### PR DESCRIPTION
No changes to AWS, just moving the LB from staging -> common to allow it to be used by prod resources.

```powershell
# pull remote state to local
terraform state pull > terraform.tfstate

# copy module to common tfstate, same module name
cd ..\staging
terraform state mv -state-out="..\common\terraform.tfstate" "module.load_balancer" "module.load_balancer"

# push updated state
cd ..\common
terraform state push
```