### PR TITLE
Update stageprd hostnames, remove hardcoded values

### DIFF
--- a/infrastructure/common/data.tf
+++ b/infrastructure/common/data.tf
@@ -1,0 +1,13 @@
+# remote-state for Wellcome shared platform-infra
+# https://github.com/wellcomecollection/platform-infrastructure/tree/master/critical/back_end
+
+data "terraform_remote_state" "platform_infra" {
+  backend = "s3"
+
+  config = {
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/platform-infrastructure/shared.tfstate"
+    region   = "eu-west-1"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"    
+  }
+}

--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "staging" {
   name        = "iiif-builder-staging-security-group"
   description = "Allow traffic"
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   ingress {
     from_port = 0
@@ -29,10 +29,10 @@ module "load_balancer" {
   source = "../modules/load_balancer"
 
   name        = "iiif-builder"
-  environment = "stage"
+  environment = "shared"
 
-  public_subnets = local.vpc_public_subnets
-  vpc_id         = local.vpc_id
+  public_subnets = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_public_subnets
+  vpc_id         = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   service_lb_security_group_ids = [
     aws_security_group.staging.id,
@@ -95,8 +95,8 @@ module "bastion" {
   instance_type = "t2.micro"
   ami           = "ami-047bb4163c506cd98"
 
-  vpc_id                     = local.vpc_id
-  subnets                    = local.vpc_public_subnets
+  vpc_id                     = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
+  subnets                    = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_public_subnets
   service_security_group_ids = [aws_security_group.staging.id]
   key_name                   = "iiif-builder"
   ip_whitelist = [
@@ -107,7 +107,7 @@ module "bastion" {
 resource "aws_service_discovery_private_dns_namespace" "iiif_builder" {
   name        = "iiif_builder"
   description = "Private ServiceDiscovery namespace for iiif-builder apps"
-  vpc         = local.vpc_id
+  vpc         = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   tags = {
     Terraform = true

--- a/infrastructure/common/readme.md
+++ b/infrastructure/common/readme.md
@@ -2,4 +2,25 @@
 
 Contains any infrastructure that is common to both the Staging and Production environments of iiif-builder.
 
-E.g. container registry, bastion server
+## Services
+
+- Security Groups - these are not shared across environments but some shared resources require them. Added here to avoid circular dependency between 'Common' and environment specific states.
+- Load Balancer - both Staging and Production share LB.
+- Container Registeries - ECR per application.
+- Bastion Server - t2.micro, IP restricted access.
+- Private Service Discovery namespace
+
+## Outputs
+
+| Name                            | Description                                   |
+|---------------------------------|-----------------------------------------------|
+| iiif_builder_url                | URL for iiif-builder ECR repo                 |
+| dashboard_url                   | URL for dashboard ECR repo                    |
+| workflow_processor_url          | URL for workflow-processor ECR repo           |
+| job_processor_url               | URL for job-processor ECR repo                |
+| staging_security_group_id       | id of 'staging' security group                |
+| service_discovery_namespace_id  | id of service discovery namespace             |
+| service_discovery_namespace_arn | arn of service discovery namespace            |
+| lb_listener_arn                 | arn of https listener                         |
+| lb_zone_id                      | canonical hosted zone ID of the load balancer |
+| lb_fqdn                         | fqdn for loat balancer                        |

--- a/infrastructure/common/variables.tf
+++ b/infrastructure/common/variables.tf
@@ -1,18 +1,3 @@
-locals {
-
-  vpc_id = "vpc-0422549322a611c44"
-  vpc_private_subnets = [
-    "subnet-061cc8889c4af6419",
-    "subnet-03a403bd266f8069a",
-    "subnet-0b268a7a49008970a",
-  ]
-  vpc_public_subnets = [
-    "subnet-0665cc7fa261ad8a4",
-    "subnet-04ea48a807334030a",
-    "subnet-0622d36b429f850f3",
-  ]
-}
-
 variable "region" {
   default = "eu-west-1"
 }

--- a/infrastructure/modules/load_balancer/security_groups.tf
+++ b/infrastructure/modules/load_balancer/security_groups.tf
@@ -30,4 +30,8 @@ resource "aws_security_group" "web" {
     local.common_tags,
     map("Name", "${local.full_name}-external-lb")
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -4,7 +4,7 @@ module "dashboard" {
 
   name        = "iiif-builder-dashboard"
   environment = local.environment
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image   = "${data.terraform_remote_state.common.outputs.dashboard_url}:staging"
   container_port = 80
@@ -14,7 +14,7 @@ module "dashboard" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   healthcheck_path = "/management/healthcheck"
@@ -85,7 +85,7 @@ module "dashboard_stageprod" {
 
   name        = "iiif-builder-dashboard"
   environment = local.environment_alt
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image   = "${data.terraform_remote_state.common.outputs.dashboard_url}:staging-prod"
   container_port = 80
@@ -95,7 +95,7 @@ module "dashboard_stageprod" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   healthcheck_path = "/management/healthcheck"

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -105,7 +105,7 @@ module "dashboard_stageprod" {
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 60
-  hostname          = "dds-stageprd"
+  hostname          = "dds-test"
   domain            = local.domain
   zone_id           = data.aws_route53_zone.external.id
 

--- a/infrastructure/staging/data.tf
+++ b/infrastructure/staging/data.tf
@@ -8,3 +8,16 @@ data "terraform_remote_state" "common" {
     region = "eu-west-1"
   }
 }
+
+# remote-state for Wellcome shared platform-infra
+# https://github.com/wellcomecollection/platform-infrastructure/tree/master/critical/back_end
+data "terraform_remote_state" "platform_infra" {
+  backend = "s3"
+
+  config = {
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/platform-infrastructure/shared.tfstate"
+    region   = "eu-west-1"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+  }
+}

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -70,7 +70,7 @@ module "iiif_builder_stageprod" {
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 50
-  hostname          = "iiif-stageprd"
+  hostname          = "iiif-test"
   domain            = local.domain
   zone_id           = data.aws_route53_zone.external.id
 

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -4,7 +4,7 @@ module "iiif_builder" {
 
   name        = "iiif-builder"
   environment = local.environment
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:staging"
   container_port = 80
@@ -14,7 +14,7 @@ module "iiif_builder" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   healthcheck_path = "/management/healthcheck"
@@ -50,7 +50,7 @@ module "iiif_builder_stageprod" {
 
   name        = "iiif-builder"
   environment = local.environment_alt
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:staging-prod"
   container_port = 80
@@ -60,7 +60,7 @@ module "iiif_builder_stageprod" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   healthcheck_path = "/management/healthcheck"

--- a/infrastructure/staging/job-processor.tf
+++ b/infrastructure/staging/job-processor.tf
@@ -4,7 +4,7 @@ module "job_processor" {
 
   name        = "job-processor"
   environment = local.environment
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image = "${data.terraform_remote_state.common.outputs.job_processor_url}:staging"
 
@@ -13,7 +13,7 @@ module "job_processor" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   secret_env_vars = {
@@ -56,7 +56,7 @@ module "job_processor_stageprod" {
 
   name        = "job-processor"
   environment = local.environment_alt
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image = "${data.terraform_remote_state.common.outputs.job_processor_url}:staging-prod"
 
@@ -65,7 +65,7 @@ module "job_processor_stageprod" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   secret_env_vars = {

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -3,11 +3,11 @@ module "rds" {
 
   name        = local.name
   environment = local.environment
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   db_instance_class = "db.m4.large"
   db_storage        = 250
-  db_subnets        = local.vpc_private_subnets
+  db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   db_ingress_cidrs  = local.vpc_private_cidr
 
   db_security_group_ids = [

--- a/infrastructure/staging/readme.md
+++ b/infrastructure/staging/readme.md
@@ -4,9 +4,14 @@ Infrastructure for IIIF-Builder Staging environment
 
 ## Configurations
 
-There are 2 configurations for the 4 main services, these correspond to the `ASPNETCORE_ENVIRONMENT` value for each environment:
-
-* Staging: Uses Staging database, DLCS and Storage API.
-* Staging-Prod: Uses Staging database, DLCS and _production_ Storage API. 
+There are 2 configurations for the 4 main services, these correspond to the `ASPNETCORE_ENVIRONMENT` value for each environment.
 
 Both configurations use the same RDS instance with separate databases. The databases share the same user across configurations.
+
+### Staging
+
+Uses Staging database, DLCS and Storage API.
+
+### Staging-Prod
+
+Uses Staging database, DLCS and _production_ Storage API. 

--- a/infrastructure/staging/variables.tf
+++ b/infrastructure/staging/variables.tf
@@ -14,18 +14,6 @@ locals {
     "Project"     = local.name
   }
 
-  # todo - take from remote state
-  vpc_id = "vpc-0422549322a611c44"
-  vpc_private_subnets = [
-    "subnet-061cc8889c4af6419",
-    "subnet-03a403bd266f8069a",
-    "subnet-0b268a7a49008970a",
-  ]
-  vpc_public_subnets = [
-    "subnet-0665cc7fa261ad8a4",
-    "subnet-04ea48a807334030a",
-    "subnet-0622d36b429f850f3",
-  ]
   vpc_private_cidr = [
     "172.56.128.0/19",
     "172.56.160.0/19",

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -4,7 +4,7 @@ module "workflow_processor" {
 
   name        = "workflow-processor"
   environment = local.environment
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:staging"
 
@@ -13,7 +13,7 @@ module "workflow_processor" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   secret_env_vars = {
@@ -60,7 +60,7 @@ module "workflow_processor_stageprod" {
 
   name        = "workflow-processor"
   environment = local.environment_alt
-  vpc_id      = local.vpc_id
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:staging-prod"
 
@@ -69,7 +69,7 @@ module "workflow_processor_stageprod" {
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
-  service_subnets                = local.vpc_private_subnets
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
 
   secret_env_vars = {


### PR DESCRIPTION
Updates hostnames:
* `dds-stgprd.dlcs.io` -> `dds-test.dlcs.io`
* `iiif-stgprd.dlcs.io` -> `iiif-test.dlcs.io`

Update Load_Balancer environment to 'shared', rather than 'stage'

Rather than hardcode vpc values, use terraform remote_state datasource. Private CIDR still hardcoded until this PR merged: https://github.com/wellcomecollection/platform-infrastructure/pull/42