### PR TITLE
Start/stop tasks on schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Current Terraform version: 0.12.x
 
 > Note: Networking infrastructure (VPC + Subnets) are managed in the central [platform-infrastructure](https://github.com/wellcomecollection/platform-infrastructure/) repository.
 
-> Note: S3 access to Wellcome buckets `wellcomecollection-storage` and `wellcomecollection-staging-storage` will need symmetric permissions in [storage-services](https://github.com/wellcomecollection/storage-service/).
-
 ## Table of Contents
 
 * [common](/infrastructure/common/readme.md)
@@ -21,7 +19,7 @@ Current Terraform version: 0.12.x
 
 ## Shared Infrastructure
 
-Both Staging and Production share common infrastructure, including LoadBalancer. As such priority rules need to take into account all environments. The environments + priorities are:
+Both Staging and Production share common infrastructure, including LoadBalancer. As such priority rules need to take into account all environments. The hostnames + priorities are:
 
 | Priority | Rule                                                         |
 |----------|--------------------------------------------------------------|
@@ -37,3 +35,17 @@ Both Staging and Production share common infrastructure, including LoadBalancer.
 | 10       | dds-test.dlcs.io -> dashboard-stageprd                       |
 | 11       | iiif.dlcs.io -> iiif-builder-prod                            |
 | 12       | dds.dlcs.io -> dashboard-prod                                |
+
+## Permissions
+
+Assumed roles are used for accessing AWS. When using this Terraform, 2 profiles are needed as resources are used from different AWS accounts.
+
+1. `main-wellcome` 
+  - the 'main' Wellcome Cloud account. 
+  - this is only used for accessing resources not in the main dlcs AWS account (`data "terraform_remote_state" "platform_infra"` resources).
+2. `dev-wellcome` 
+  - the profile that uses `main-wellcome` as source_profile to assume `digirati-developer` iam role. 
+  - used for all resources in main dlcs AWS account (`provider`, `terraform` and other `data "terraform_remote_state"`).
+
+> There may be other/better ways to achieve this!
+

--- a/infrastructure/modules/autoscaling/scheduled/main.tf
+++ b/infrastructure/modules/autoscaling/scheduled/main.tf
@@ -1,13 +1,7 @@
-# AWS provided role for ECS app autoscaling
-data "aws_iam_role" "ecs_autoscaling" {
-  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
-}
-
 resource "aws_appautoscaling_target" "service_scale_target" {
   service_namespace  = "ecs"
   resource_id        = local.resource_id
   scalable_dimension = "ecs:service:DesiredCount"
-  role_arn           = data.aws_iam_role.ecs_autoscaling.arn
   min_capacity       = var.scale_down_min
   max_capacity       = var.scale_up_max
 }
@@ -30,7 +24,7 @@ resource "aws_appautoscaling_scheduled_action" "scale_down" {
   service_namespace  = aws_appautoscaling_target.service_scale_target.service_namespace
   resource_id        = aws_appautoscaling_target.service_scale_target.resource_id
   scalable_dimension = aws_appautoscaling_target.service_scale_target.scalable_dimension
-  schedule           = var.scale_up_schedule
+  schedule           = var.scale_down_schedule
 
   scalable_target_action {
     min_capacity = var.scale_down_min

--- a/infrastructure/modules/autoscaling/scheduled/main.tf
+++ b/infrastructure/modules/autoscaling/scheduled/main.tf
@@ -1,0 +1,39 @@
+# AWS provided role for ECS app autoscaling
+data "aws_iam_role" "ecs_autoscaling" {
+  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}
+
+resource "aws_appautoscaling_target" "service_scale_target" {
+  service_namespace  = "ecs"
+  resource_id        = local.resource_id
+  scalable_dimension = "ecs:service:DesiredCount"
+  role_arn           = data.aws_iam_role.ecs_autoscaling.arn
+  min_capacity       = var.scale_down_min
+  max_capacity       = var.scale_up_max
+}
+
+resource "aws_appautoscaling_scheduled_action" "scale_up" {
+  name               = "scale-up-${var.service_name}"
+  service_namespace  = aws_appautoscaling_target.service_scale_target.service_namespace
+  resource_id        = aws_appautoscaling_target.service_scale_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.service_scale_target.scalable_dimension
+  schedule           = var.scale_up_schedule
+
+  scalable_target_action {
+    min_capacity = var.scale_up_min
+    max_capacity = var.scale_up_max
+  }
+}
+
+resource "aws_appautoscaling_scheduled_action" "scale_down" {
+  name               = "scale-down-${var.service_name}"
+  service_namespace  = aws_appautoscaling_target.service_scale_target.service_namespace
+  resource_id        = aws_appautoscaling_target.service_scale_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.service_scale_target.scalable_dimension
+  schedule           = var.scale_up_schedule
+
+  scalable_target_action {
+    min_capacity = var.scale_down_min
+    max_capacity = var.scale_down_max
+  }
+}

--- a/infrastructure/modules/autoscaling/scheduled/outputs.tf
+++ b/infrastructure/modules/autoscaling/scheduled/outputs.tf
@@ -1,0 +1,7 @@
+output "scale_down_arn" {
+  value = aws_appautoscaling_scheduled_action.scale_down.arn
+}
+
+output "scale_up_arn" {
+  value = aws_appautoscaling_scheduled_action.scale_up.arn
+}

--- a/infrastructure/modules/autoscaling/scheduled/variables.tf
+++ b/infrastructure/modules/autoscaling/scheduled/variables.tf
@@ -30,12 +30,13 @@ variable "scale_down_max" {
   default     = 0
 }
 
+# see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 variable "scale_up_schedule" {
   description = "When to scale up. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
-  default = "cron(0 7 * * *)"
+  default = "cron(0 7 * * ? *)"
 }
 
 variable "scale_down_schedule" {
   description = "When to scale down. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
-  default = "cron(0 19 * * *)"
+  default = "cron(0 19 * * ? *)"
 }

--- a/infrastructure/modules/autoscaling/scheduled/variables.tf
+++ b/infrastructure/modules/autoscaling/scheduled/variables.tf
@@ -1,0 +1,41 @@
+locals {
+  resource_id = "service/${var.cluster_name}/${var.service_name}"
+}
+
+variable "cluster_name" {
+  description = "Name of cluster services running on"
+}
+
+variable "service_name" {
+  description = "Name of ECS service to scale"
+}
+
+variable "scale_up_min" {
+  description = "Minimum capacity when scaled up"
+  default     = 1
+}
+
+variable "scale_up_max" {
+  description = "Maximum capacity when scaled up"
+  default     = 1
+}
+
+variable "scale_down_min" {
+  description = "Minimum capacity when scaled down"
+  default     = 0
+}
+
+variable "scale_down_max" {
+  description = "Maximum capacity when scaled up"
+  default     = 0
+}
+
+variable "scale_up_schedule" {
+  description = "When to scale up. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
+  default = "cron(0 7 * * *)"
+}
+
+variable "scale_down_schedule" {
+  description = "When to scale down. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
+  default = "cron(0 19 * * *)"
+}

--- a/infrastructure/modules/ecs/private/outputs.tf
+++ b/infrastructure/modules/ecs/private/outputs.tf
@@ -5,3 +5,7 @@ output "task_role_name" {
 output "task_role_arn" {
   value = module.task_definition.task_role_arn
 }
+
+output "service_name" {
+  value = module.service.name
+}

--- a/infrastructure/modules/ecs/web/outputs.tf
+++ b/infrastructure/modules/ecs/web/outputs.tf
@@ -9,3 +9,7 @@ output "task_role_arn" {
 output "service_target_group_arn"{
   value = aws_alb_target_group.service.arn
 }
+
+output "service_name" {
+  value = module.service.name
+}

--- a/infrastructure/modules/readme.md
+++ b/infrastructure/modules/readme.md
@@ -8,3 +8,5 @@ A collection of reusable modules
   * web - creates Fargate ECS service and task definition with logging configured. Also creates alb targetgroup, rules and route53 A record.
 * load_balancer - ELB with http -> https redirect using certificate already in AWS.
 * rds - created PostgreSQL RDS instance
+* autoscaling/
+  * scheduled - scheduled autoscaling to run on specified schedule.

--- a/infrastructure/production/dashboard.tf
+++ b/infrastructure/production/dashboard.tf
@@ -9,7 +9,7 @@ module "dashboard" {
   docker_image   = "${data.terraform_remote_state.common.outputs.dashboard_url}:production"
   container_port = 80
 
-  cpu    = 256
+  cpu    = 512
   memory = 2048
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn

--- a/infrastructure/production/workflow-processor.tf
+++ b/infrastructure/production/workflow-processor.tf
@@ -8,7 +8,7 @@ module "workflow_processor" {
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:production"
 
-  cpu    = 256
+  cpu    = 512
   memory = 2048
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -97,7 +97,7 @@ module "dashboard_stageprod" {
   docker_image   = "${data.terraform_remote_state.common.outputs.dashboard_url}:staging-prod"
   container_port = 80
 
-  cpu    = 256
+  cpu    = 512
   memory = 2048
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -138,6 +138,13 @@ module "dashboard_stageprod" {
   }
 }
 
+module "dashboard_stageprod_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.dashboard_stageprod.service_name
+}
+
 data "aws_iam_role" "dashboardstgprd_task_role" {
   name = module.dashboard_stageprod.task_role_name
 }

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -50,6 +50,13 @@ module "dashboard" {
   }
 }
 
+module "dashboard_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.dashboard.service_name
+}
+
 data "aws_iam_role" "dashboard_task_role" {
   name = module.dashboard.task_role_name
 }

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -48,6 +48,12 @@ module "iiif_builder" {
   }
 }
 
+module "iiif_builder_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.iiif_builder.service_name
+}
 
 data "aws_iam_role" "iiifbuilder_task_role" {
   name = module.iiif_builder.task_role_name

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -135,6 +135,13 @@ module "iiif_builder_stageprod" {
   }
 }
 
+module "iiif_builder_stageprod_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.iiif_builder_stageprod.service_name
+}
+
 data "aws_iam_role" "iiifbuilderstgprd_task_role" {
   name = module.iiif_builder_stageprod.task_role_name
 }

--- a/infrastructure/staging/job-processor.tf
+++ b/infrastructure/staging/job-processor.tf
@@ -108,6 +108,13 @@ module "job_processor_stageprod" {
   }
 }
 
+module "job_processor_stageprod_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.job_processor_stageprod.service_name
+}
+
 data "aws_iam_role" "jobprocessorstgprd_task_role" {
   name = module.job_processor_stageprod.task_role_name
 }

--- a/infrastructure/staging/job-processor.tf
+++ b/infrastructure/staging/job-processor.tf
@@ -38,6 +38,13 @@ module "job_processor" {
   }
 }
 
+module "job_processor_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.job_processor.service_name
+}
+
 data "aws_iam_role" "jobprocessor_task_role" {
   name = module.job_processor.task_role_name
 }

--- a/infrastructure/staging/readme.md
+++ b/infrastructure/staging/readme.md
@@ -4,9 +4,11 @@ Infrastructure for IIIF-Builder Staging environment
 
 ## Configurations
 
-There are 2 configurations for the 4 main services, these correspond to the `ASPNETCORE_ENVIRONMENT` value for each environment.
+There are 2 configurations for the 4 main services, these correspond to the `ASPNETCORE_ENVIRONMENT` value for each environment:
 
 Both configurations use the same RDS instance with separate databases. The databases share the same user across configurations.
+
+ECS tasks are scheduled to turn off at 1900 and back on again at 0700 UTC.
 
 ### Staging
 
@@ -14,4 +16,4 @@ Uses Staging database, DLCS and Storage API.
 
 ### Staging-Prod
 
-Uses Staging database, DLCS and _production_ Storage API. 
+Uses Staging database, DLCS and _production_ Storage API. Hostnames use `test` for this environment.

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -82,7 +82,7 @@ module "workflow_processor_stageprod" {
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:staging-prod"
 
-  cpu    = 256
+  cpu    = 512
   memory = 2048
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -36,6 +36,13 @@ module "workflow_processor" {
   }
 }
 
+module "workflow_processor_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.workflow_processor.service_name
+}
+
 data "aws_iam_role" "workflowprocessor_task_role" {
   name = module.workflow_processor.task_role_name
 }

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -110,6 +110,13 @@ module "workflow_processor_stageprod" {
   }
 }
 
+module "workflow_processor_stageprod_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.workflow_processor_stageprod.service_name
+}
+
 data "aws_iam_role" "workflowprocessorstgprd_task_role" {
   name = module.workflow_processor_stageprod.task_role_name
 }


### PR DESCRIPTION
Also increased vcpu + memory for dashboard + workflow processor.

C&D still kills dashboard at these levels but reduced them back from where it seems more stable (2048/4096) until we figure out hwo best to handle.