### PR TITLE
Fix issue where scaling target min_capacity was always changing

### DIFF
--- a/infrastructure/modules/autoscaling/scheduled/main.tf
+++ b/infrastructure/modules/autoscaling/scheduled/main.tf
@@ -2,32 +2,32 @@ resource "aws_appautoscaling_target" "service_scale_target" {
   service_namespace  = "ecs"
   resource_id        = local.resource_id
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.scale_down_min
-  max_capacity       = var.scale_up_max
+  min_capacity       = var.scale_out_min
+  max_capacity       = var.scale_out_max
 }
 
-resource "aws_appautoscaling_scheduled_action" "scale_up" {
+resource "aws_appautoscaling_scheduled_action" "scale_out" {
   name               = "scale-up-${var.service_name}"
   service_namespace  = aws_appautoscaling_target.service_scale_target.service_namespace
   resource_id        = aws_appautoscaling_target.service_scale_target.resource_id
   scalable_dimension = aws_appautoscaling_target.service_scale_target.scalable_dimension
-  schedule           = var.scale_up_schedule
+  schedule           = var.scale_out_schedule
 
   scalable_target_action {
-    min_capacity = var.scale_up_min
-    max_capacity = var.scale_up_max
+    min_capacity = var.scale_out_min
+    max_capacity = var.scale_out_max
   }
 }
 
-resource "aws_appautoscaling_scheduled_action" "scale_down" {
+resource "aws_appautoscaling_scheduled_action" "scale_in" {
   name               = "scale-down-${var.service_name}"
   service_namespace  = aws_appautoscaling_target.service_scale_target.service_namespace
   resource_id        = aws_appautoscaling_target.service_scale_target.resource_id
   scalable_dimension = aws_appautoscaling_target.service_scale_target.scalable_dimension
-  schedule           = var.scale_down_schedule
+  schedule           = var.scale_in_schedule
 
   scalable_target_action {
-    min_capacity = var.scale_down_min
-    max_capacity = var.scale_down_max
+    min_capacity = var.scale_in_min
+    max_capacity = var.scale_in_max
   }
 }

--- a/infrastructure/modules/autoscaling/scheduled/outputs.tf
+++ b/infrastructure/modules/autoscaling/scheduled/outputs.tf
@@ -1,7 +1,7 @@
-output "scale_down_arn" {
-  value = aws_appautoscaling_scheduled_action.scale_down.arn
+output "scale_in_arn" {
+  value = aws_appautoscaling_scheduled_action.scale_in.arn
 }
 
-output "scale_up_arn" {
-  value = aws_appautoscaling_scheduled_action.scale_up.arn
+output "scale_out_arn" {
+  value = aws_appautoscaling_scheduled_action.scale_out.arn
 }

--- a/infrastructure/modules/autoscaling/scheduled/variables.tf
+++ b/infrastructure/modules/autoscaling/scheduled/variables.tf
@@ -10,33 +10,33 @@ variable "service_name" {
   description = "Name of ECS service to scale"
 }
 
-variable "scale_up_min" {
-  description = "Minimum capacity when scaled up"
+variable "scale_out_min" {
+  description = "Minimum capacity when scaled out"
   default     = 1
 }
 
-variable "scale_up_max" {
-  description = "Maximum capacity when scaled up"
+variable "scale_out_max" {
+  description = "Maximum capacity when scaled out"
   default     = 1
 }
 
-variable "scale_down_min" {
-  description = "Minimum capacity when scaled down"
+variable "scale_in_min" {
+  description = "Minimum capacity when scaled in"
   default     = 0
 }
 
-variable "scale_down_max" {
-  description = "Maximum capacity when scaled up"
+variable "scale_in_max" {
+  description = "Maximum capacity when scaled in"
   default     = 0
 }
 
 # see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
-variable "scale_up_schedule" {
-  description = "When to scale up. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
+variable "scale_out_schedule" {
+  description = "When to scale out. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
   default = "cron(0 7 * * ? *)"
 }
 
-variable "scale_down_schedule" {
-  description = "When to scale down. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
+variable "scale_in_schedule" {
+  description = "When to scale in. The following formats are supported: At expressions - at(yyyy-mm-ddThh:mm:ss), Rate expressions - rate(valueunit), Cron expressions - cron(fields)"
   default = "cron(0 19 * * ? *)"
 }

--- a/infrastructure/staging/readme.md
+++ b/infrastructure/staging/readme.md
@@ -10,6 +10,8 @@ Both configurations use the same RDS instance with separate databases. The datab
 
 ECS tasks are scheduled to turn off at 1900 and back on again at 0700 UTC.
 
+> A note on scaling - the assumption is that any `tf apply` operations will be run when services are running (scaled-out). If run outside of these times there will be changes related to scale target.
+
 ### Staging
 
 Uses Staging database, DLCS and Storage API.


### PR DESCRIPTION
Also took opportunity to rename scale up/down to scale out/in.

Main change is 

```hcl
min_capacity = var.scale_down_min => min_capacity = var.scale_out_min
``` 

the rest is naming fix