### PR TITLE
Add dlcs secrets to workflow-processor tasks

### DIFF
--- a/infrastructure/production/workflow-processor.tf
+++ b/infrastructure/production/workflow-processor.tf
@@ -21,6 +21,8 @@ module "workflow_processor" {
     ConnectionStrings__Dds                = "iiif-builder/production/dds-connstr"
     Storage__ClientId                     = "iiif-builder/common/storage/clientid"
     Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+    Dlcs__ApiKey                          = "iiif-builder/common/dlcs-apikey"
+    Dlcs__ApiSecret                       = "iiif-builder/common/dlcs-apisecret"
   }
 
   env_vars = {

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -21,6 +21,8 @@ module "workflow_processor" {
     ConnectionStrings__Dds                = "iiif-builder/staging/dds-connstr"
     Storage__ClientId                     = "iiif-builder/common/storage/clientid"
     Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+    Dlcs__ApiKey                          = "iiif-builder/common/dlcs-apikey"
+    Dlcs__ApiSecret                       = "iiif-builder/common/dlcs-apisecret"
   }
 
   env_vars = {
@@ -91,6 +93,8 @@ module "workflow_processor_stageprod" {
     ConnectionStrings__Dds                = "iiif-builder/staging/ddsstgprd-connstr"
     Storage__ClientId                     = "iiif-builder/common/storage/clientid"
     Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+    Dlcs__ApiKey                          = "iiif-builder/common/dlcs-apikey"
+    Dlcs__ApiSecret                       = "iiif-builder/common/dlcs-apisecret"
   }
 
   env_vars = {


### PR DESCRIPTION
Workflow-processor doesn't call the DLCS but secrets are required due to IDLCS dependency in object graph.

This has already been applied.