### PR TITLE
Use the new location of Digirati VPC tfstate

### DIFF
--- a/infrastructure/common/data.tf
+++ b/infrastructure/common/data.tf
@@ -1,13 +1,13 @@
 # remote-state for Wellcome shared platform-infra
-# https://github.com/wellcomecollection/platform-infrastructure/tree/master/critical/back_end
+# https://github.com/wellcomecollection/platform-infrastructure/tree/master/accounts/digirati
 
 data "terraform_remote_state" "platform_infra" {
   backend = "s3"
 
   config = {
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/digirati.tfstate"
     region   = "eu-west-1"
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"    
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
   }
 }

--- a/infrastructure/production/data.tf
+++ b/infrastructure/production/data.tf
@@ -10,13 +10,13 @@ data "terraform_remote_state" "common" {
 }
 
 # remote-state for Wellcome shared platform-infra
-# https://github.com/wellcomecollection/platform-infrastructure/tree/master/critical/back_end
+# https://github.com/wellcomecollection/platform-infrastructure/tree/master/accounts/digirati
 data "terraform_remote_state" "platform_infra" {
   backend = "s3"
 
   config = {
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/digirati.tfstate"
     region   = "eu-west-1"
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
   }

--- a/infrastructure/staging/data.tf
+++ b/infrastructure/staging/data.tf
@@ -10,13 +10,13 @@ data "terraform_remote_state" "common" {
 }
 
 # remote-state for Wellcome shared platform-infra
-# https://github.com/wellcomecollection/platform-infrastructure/tree/master/critical/back_end
+# https://github.com/wellcomecollection/platform-infrastructure/tree/master/accounts/digirati
 data "terraform_remote_state" "platform_infra" {
   backend = "s3"
 
   config = {
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/digirati.tfstate"
     region   = "eu-west-1"
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
   }


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4802

We've rearranged some of our Terraform configs to reduce the amount of cross-account coupling. Changing the storage VPC shouldn't affect the Digirati VPC, etc. I've already checked this is a no-op.