### PR TITLE
Add hosted zone for wc.digirati.io

### DIFF
--- a/infrastructure/common/dns.tf
+++ b/infrastructure/common/dns.tf
@@ -1,0 +1,3 @@
+resource "aws_route53_zone" "wellcomecollection_digirati_io" {
+  name = "wellcomecollection.digirati.io"
+}

--- a/infrastructure/common/outputs.tf
+++ b/infrastructure/common/outputs.tf
@@ -45,3 +45,11 @@ output "lb_zone_id" {
 output "lb_fqdn" {
   value = module.load_balancer.lb_dns_name
 }
+
+output "wellcomecollection_digirati_io_zone_id" {
+  value = aws_route53_zone.wellcomecollection_digirati_io.zone_id
+}
+
+output "wellcomecollection_digirati_io" {
+  value = aws_route53_zone.wellcomecollection_digirati_io.name
+}

--- a/infrastructure/common/readme.md
+++ b/infrastructure/common/readme.md
@@ -9,20 +9,23 @@ Contains any infrastructure that is common to both the Staging and Production en
 - Container Registeries - ECR per application.
 - Bastion Server - t2.micro, IP restricted access.
 - Private Service Discovery namespace
+- Route53 hosted zone for `wellcomecollection.digirati.io`
 
 ## Outputs
 
-| Name                            | Description                                   |
-|---------------------------------|-----------------------------------------------|
-| iiif_builder_url                | URL for iiif-builder ECR repo                 |
-| dashboard_url                   | URL for dashboard ECR repo                    |
-| workflow_processor_url          | URL for workflow-processor ECR repo           |
-| job_processor_url               | URL for job-processor ECR repo                |
-| pdf_generator_url               | URL for pdf-generator ECR repo                |
-| staging_security_group_id       | id of 'staging' security group                |
-| production_security_group_id    | id of 'production' security group             |
-| service_discovery_namespace_id  | id of service discovery namespace             |
-| service_discovery_namespace_arn | arn of service discovery namespace            |
-| lb_listener_arn                 | arn of https listener                         |
-| lb_zone_id                      | canonical hosted zone ID of the load balancer |
-| lb_fqdn                         | fqdn for loat balancer                        |
+| Name                                   | Description                                   |
+|----------------------------------------|-----------------------------------------------|
+| iiif_builder_url                       | URL for iiif-builder ECR repo                 |
+| dashboard_url                          | URL for dashboard ECR repo                    |
+| workflow_processor_url                 | URL for workflow-processor ECR repo           |
+| job_processor_url                      | URL for job-processor ECR repo                |
+| pdf_generator_url                      | URL for pdf-generator ECR repo                |
+| staging_security_group_id              | id of 'staging' security group                |
+| production_security_group_id           | id of 'production' security group             |
+| service_discovery_namespace_id         | id of service discovery namespace             |
+| service_discovery_namespace_arn        | arn of service discovery namespace            |
+| lb_listener_arn                        | arn of https listener                         |
+| lb_zone_id                             | canonical hosted zone ID of the load balancer |
+| lb_fqdn                                | fqdn for loat balancer                        |
+| wellcomecollection_digirati_io         | DNS name for hosted zone                      |
+| wellcomecollection_digirati_io_zone_id | ZoneId for hosted zone                        |


### PR DESCRIPTION
Add new hosted-zone for `wellcomecollection.digirati.io` for dds services.

This removes dependency on `dlcs.io` and keeps everything separate.

We will need to setup NS records in `digirati.io` prior to updating services to use this.

```hcl
Terraform will perform the following actions:

  # aws_route53_zone.wellcomecollection_digirati_io will be created
  + resource "aws_route53_zone" "wellcomecollection_digirati_io" {
      + comment       = "Managed by Terraform"
      + force_destroy = false
      + name          = "wellcomecollection.digirati.io"
      + name_servers  = (known after apply)
      + zone_id       = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```