### PR TITLE
Domain updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,25 @@ Current Terraform version: 0.14.x
 
 Both Staging and Production share common infrastructure, including LoadBalancer. As such priority rules need to take into account all environments. The hostnames + priorities are:
 
-     | Priority | Rule                                                                |
------|----------|---------------------------------------------------------------------|----
-     | 1        | iiif.wellcomecollection.org/dash* -> dashboard-prod                 |
-     | 2        | iiif.wellcomecollection.org -> iiif-builder-prod                    |
-     | 3        | iiif-stage.wellcomecollection.org/dash* -> dashboard-stage          |
-     | 4        | pdf-stage.dlcs.io -> pdf-generator-stage                            |
-     | 5        | iiif-test.wellcomecollection.org/dash* -> dashboard-stageprd        |
-     | 7        | iiif-stage.dlcs.io -> iiif-builder-stage                            |
-     | 8        | dds-stage.dlcs.io -> dashboard-stage                                |
-     | 9        | iiif-test.dlcs.io -> iiif-builder-stageprd                          |
-     | 10       | dds-test.dlcs.io -> dashboard-stageprd                              |
-     | 11       | iiif.dlcs.io -> iiif-builder-prod                                   |
-     | 12       | dds.dlcs.io -> dashboard-prod                                       |
-     | 20       | iiif-test.wellcomecollection.org -> iiif-builder-stageprd           |
-     | 21       | iiif-stage.wellcomecollection.org -> iiif-builder-stage             |
-     | 22       | pdf.dlcs.io -> pdf-generator-prod                                   |
+     | Priority | Rule                                                            |
+     |----------|-----------------------------------------------------------------|
+     | 1        | iiif.wellcomecollection.org/dash* -> dashboard-prod             |
+     | 2        | iiif.wellcomecollection.org -> iiif-builder-prod                |
+     | 3        | iiif-stage.wellcomecollection.org/dash* -> dashboard-stage      |
+     | 4        | pdf-stage.dlcs.io -> pdf-generator-stage                        |
+     | 5        | iiif-test.wellcomecollection.org/dash* -> dashboard-stageprd    |
+     | 6        | pdf-stage.wellcomecollection.digirati.io -> pdf-generator-stage |
+     | 7        | iiif-stage.dlcs.io -> iiif-builder-stage                        |
+     | 8        | dds-stage.dlcs.io -> dashboard-stage                            |
+     | 9        | iiif-test.dlcs.io -> iiif-builder-stageprd                      |
+     | 10       | dds-test.dlcs.io -> dashboard-stageprd                          |
+     | 11       | iiif.dlcs.io -> iiif-builder-prod                               |
+     | 12       | dds.dlcs.io -> dashboard-prod                                   |
+     | 20       | iiif-test.wellcomecollection.org -> iiif-builder-stageprd       |
+     | 21       | iiif-stage.wellcomecollection.org -> iiif-builder-stage         |
+     | 22       | pdf.dlcs.io -> pdf-generator-prod                               |
+
+
 <!-- | 23       | iiif-stage.wellcomecollection.org/pdf-cover* -> pdf-generator-test  |
      | 24       | iiif-stage.wellcomecollection.org/pdf-cover* -> pdf-generator-stage | -->
 

--- a/README.md
+++ b/README.md
@@ -21,23 +21,27 @@ Current Terraform version: 0.14.x
 
 Both Staging and Production share common infrastructure, including LoadBalancer. As such priority rules need to take into account all environments. The hostnames + priorities are:
 
-     | Priority | Rule                                                            |
-     |----------|-----------------------------------------------------------------|
-     | 1        | iiif.wellcomecollection.org/dash* -> dashboard-prod             |
-     | 2        | iiif.wellcomecollection.org -> iiif-builder-prod                |
-     | 3        | iiif-stage.wellcomecollection.org/dash* -> dashboard-stage      |
-     | 4        | pdf-stage.dlcs.io -> pdf-generator-stage                        |
-     | 5        | iiif-test.wellcomecollection.org/dash* -> dashboard-stageprd    |
-     | 6        | pdf-stage.wellcomecollection.digirati.io -> pdf-generator-stage |
-     | 7        | iiif-stage.dlcs.io -> iiif-builder-stage                        |
-     | 8        | dds-stage.dlcs.io -> dashboard-stage                            |
-     | 9        | iiif-test.dlcs.io -> iiif-builder-stageprd                      |
-     | 10       | dds-test.dlcs.io -> dashboard-stageprd                          |
-     | 11       | iiif.dlcs.io -> iiif-builder-prod                               |
-     | 12       | dds.dlcs.io -> dashboard-prod                                   |
-     | 20       | iiif-test.wellcomecollection.org -> iiif-builder-stageprd       |
-     | 21       | iiif-stage.wellcomecollection.org -> iiif-builder-stage         |
-     | 22       | pdf.dlcs.io -> pdf-generator-prod                               |
+| Priority | Rule                                                             |
+|----------|------------------------------------------------------------------|
+| 1        | iiif.wellcomecollection.org/dash* -> dashboard-prod              |
+| 2        | iiif.wellcomecollection.org -> iiif-builder-prod                 |
+| 3        | iiif-stage.wellcomecollection.org/dash* -> dashboard-stage       |
+| 4        | pdf-stage.dlcs.io -> pdf-generator-stage                         |
+| 5        | iiif-test.wellcomecollection.org/dash* -> dashboard-stageprd     |
+| 6        | pdf-stage.wellcomecollection.digirati.io -> pdf-generator-stage  |
+| 7        | dds-stage.wellcomecollection.digirati.io -> iiif-builder-stage   |
+| 8        | dash-stage.wellcomecollection.digirati.io -> dashboard-stage     |
+| 9        | dds-test.wellcomecollection.digirati.io -> iiif-builder-stageprd |
+| 10       | dash-test.wellcomecollection.digirati.io -> dashboard-stageprd   |
+| 11       | iiif.dlcs.io -> iiif-builder-prod                                |
+| 12       | dds.dlcs.io -> dashboard-prod                                    |
+| 20       | iiif-test.wellcomecollection.org -> iiif-builder-stageprd        |
+| 21       | iiif-stage.wellcomecollection.org -> iiif-builder-stage          |
+| 22       | pdf.dlcs.io -> pdf-generator-prod                                |
+| 30       | dds-stage.dlcs.io -> dashboard-stage                             |
+| 31       | dds-test.dlcs.io -> dashboard-stageprd                           |
+| 32       | iiif-stage.dlcs.io -> iiif-builder-stage                         |
+| 33       | iiif-test.dlcs.io -> iiif-builder-stageprd                       |
 
 
 <!-- | 23       | iiif-stage.wellcomecollection.org/pdf-cover* -> pdf-generator-test  |

--- a/infrastructure/common/dns.tf
+++ b/infrastructure/common/dns.tf
@@ -9,6 +9,8 @@ resource "aws_acm_certificate" "cert" {
 
   subject_alternative_names = [
     "*.${local.domain}",
+    "*.dlcs.io",
+    "dlcs.io",
   ]
 
   tags = local.common_tags
@@ -19,23 +21,46 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
   allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
+  name            = tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_value]
   ttl             = 300
-  type            = each.value.type
+  type            = tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_type
   zone_id         = aws_route53_zone.wellcomecollection_digirati_io.zone_id
 }
 
+resource "aws_route53_record" "cert_validation_wildcard" {
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.cert.domain_validation_options)[1].resource_record_name
+  records         = [tolist(aws_acm_certificate.cert.domain_validation_options)[1].resource_record_value]
+  ttl             = 300
+  type            = tolist(aws_acm_certificate.cert.domain_validation_options)[1].resource_record_type
+  zone_id         = aws_route53_zone.wellcomecollection_digirati_io.zone_id
+}
+
+# resource "aws_route53_record" "cert_validation" {
+#   for_each = {
+#     for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+#       name    = dvo.resource_record_name
+#       record  = dvo.resource_record_value
+#       type    = dvo.resource_record_type
+#     }
+#   }
+
+#   allow_overwrite = true
+#   name            = each.value.name
+#   records         = [each.value.record]
+#   ttl             = 300
+#   type            = each.value.type
+#   zone_id         = aws_route53_zone.wellcomecollection_digirati_io.zone_id
+# }
+
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn         = aws_acm_certificate.cert.arn
-  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+  #validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+  validation_record_fqdns = [
+    aws_route53_record.cert_validation.fqdn,
+    aws_route53_record.cert_validation_wildcard.fqdn,
+    "_351db1641ca318b8ac18a64f892ebaf4.dlcs.io"
+  ]
 }

--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -12,7 +12,7 @@ module "load_balancer" {
     aws_security_group.production.id
   ]
 
-  certificate_arn = data.aws_acm_certificate.dlcs_io.arn # aws_acm_certificate.cert.arn
+  certificate_arn = aws_acm_certificate.cert.arn
 
   lb_controlled_ingress_cidrs = ["0.0.0.0/0"]
 }
@@ -52,16 +52,4 @@ resource "aws_service_discovery_private_dns_namespace" "iiif_builder" {
   vpc         = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   tags = local.common_tags
-}
-
-# Temporary until Wellcome CloudFront rules in place, dlcs.io
-data "aws_acm_certificate" "dlcs_io" {
-  domain      = "dlcs.io"
-  statuses    = ["ISSUED"]
-  most_recent = true
-}
-
-resource "aws_lb_listener_certificate" "new_domain" {
-  listener_arn    = module.load_balancer.https_listener_arn
-  certificate_arn = aws_acm_certificate.cert.arn #data.aws_acm_certificate.dlcs_io.arn
 }

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -24,13 +24,9 @@ module "dashboard" {
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 8
-  hostname          = "dds-stage"
-  domain            = local.domain
-  zone_id           = data.aws_route53_zone.external.id
-
-  # hostname          = "dash-stage"
-  # domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
-  # zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
+  hostname          = "dash-stage"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
 
   port_mappings = [{
     containerPort = 80
@@ -118,13 +114,9 @@ module "dashboard_stageprod" {
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 10
-  hostname          = "dds-test"
-  domain            = local.domain
-  zone_id           = data.aws_route53_zone.external.id
-
-  # hostname          = "dash-test"
-  # domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
-  # zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
+  hostname          = "dash-test"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
 
   port_mappings = [{
     containerPort = 80

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -24,13 +24,9 @@ module "iiif_builder" {
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 7
-  hostname          = "iiif-stage"
-  domain            = local.domain
-  zone_id           = data.aws_route53_zone.external.id
-
-  # hostname          = "dds-stage"
-  # domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
-  # zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
+  hostname          = "dds-stage"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
 
   port_mappings = [{
     containerPort = 80
@@ -121,13 +117,9 @@ module "iiif_builder_stageprod" {
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
   listener_priority = 9
-  hostname          = "iiif-test"
-  domain            = local.domain
-  zone_id           = data.aws_route53_zone.external.id
-
-  # hostname          = "dds-test"
-  # domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
-  # zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
+  hostname          = "dds-test"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
 
   port_mappings = [{
     containerPort = 80

--- a/infrastructure/staging/legacy_listener_rules.tf
+++ b/infrastructure/staging/legacy_listener_rules.tf
@@ -1,0 +1,176 @@
+# DNS / ALB rules for dlcs.io (will eventually be deleted)
+
+# pdf-stage
+resource "aws_alb_listener_rule" "pdf_stage_dlcs_io" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 4
+
+  action {
+    type             = "forward"
+    target_group_arn = module.pdf_generator.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["pdf-stage.${local.domain}"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "pdf_stage_dlcs_io" {
+  zone_id = data.aws_route53_zone.external.id
+  name    = "pdf-stage.${local.domain}"
+  type    = "A"
+
+  alias {
+    name                   = data.terraform_remote_state.common.outputs.lb_fqdn
+    zone_id                = data.terraform_remote_state.common.outputs.lb_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# dashboard-stage
+resource "aws_alb_listener_rule" "dashboard_stage_dlcs_io" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 30
+
+  action {
+    type             = "forward"
+    target_group_arn = module.dashboard.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["dds-stage.${local.domain}"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "dashboard_stage_dlcs_io" {
+  zone_id = data.aws_route53_zone.external.id
+  name    = "dds-stage.${local.domain}"
+  type    = "A"
+
+  alias {
+    name                   = data.terraform_remote_state.common.outputs.lb_fqdn
+    zone_id                = data.terraform_remote_state.common.outputs.lb_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# dashboard-test
+resource "aws_alb_listener_rule" "dashboard_stageprod_dlcs_io" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 31
+
+  action {
+    type             = "forward"
+    target_group_arn = module.dashboard_stageprod.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["dds-test.${local.domain}"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "dashboard_stageprod_dlcs_io" {
+  zone_id = data.aws_route53_zone.external.id
+  name    = "dds-test.${local.domain}"
+  type    = "A"
+
+  alias {
+    name                   = data.terraform_remote_state.common.outputs.lb_fqdn
+    zone_id                = data.terraform_remote_state.common.outputs.lb_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# iiif-builder-stage
+resource "aws_alb_listener_rule" "iiif_builder_stage_dlcs_io" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 32
+
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["iiif-stage.${local.domain}"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "iiif_builder_stage_dlcs_io" {
+  zone_id = data.aws_route53_zone.external.id
+  name    = "iiif-stage.${local.domain}"
+  type    = "A"
+
+  alias {
+    name                   = data.terraform_remote_state.common.outputs.lb_fqdn
+    zone_id                = data.terraform_remote_state.common.outputs.lb_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# iiif-builder-test
+resource "aws_alb_listener_rule" "iiif_builder_stageprod_dlcs_io" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 33
+
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder_stageprod.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["iiif-test.${local.domain}"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "iiif_builder_stageprod_dlcs_io" {
+  zone_id = data.aws_route53_zone.external.id
+  name    = "iiif-test.${local.domain}"
+  type    = "A"
+
+  alias {
+    name                   = data.terraform_remote_state.common.outputs.lb_fqdn
+    zone_id                = data.terraform_remote_state.common.outputs.lb_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infrastructure/staging/pdf-generator.tf
+++ b/infrastructure/staging/pdf-generator.tf
@@ -45,38 +45,3 @@ resource "aws_iam_role_policy" "pdf_generator_read_presentation_bucket" {
   role   = module.pdf_generator.task_role_name
   policy = data.aws_iam_policy_document.presentation_read.json
 }
-
-# DNS / ALB rules for dlcs.io (will eventually be deleted)
-resource "aws_alb_listener_rule" "pdf_stage_dlcs_io" {
-  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
-  priority     = 4
-
-  action {
-    type             = "forward"
-    target_group_arn = module.pdf_generator.service_target_group_arn
-  }
-
-  condition {
-    host_header {
-      values = ["pdf-stage.${local.domain}"]
-    }
-  }
-
-  condition {
-    path_pattern {
-      values = ["/*"]
-    }
-  }
-}
-
-resource "aws_route53_record" "pdf_stage_dlcs_io" {
-  zone_id = data.aws_route53_zone.external.id
-  name    = "pdf-stage.${local.domain}"
-  type    = "A"
-
-  alias {
-    name                   = data.terraform_remote_state.common.outputs.lb_fqdn
-    zone_id                = data.terraform_remote_state.common.outputs.lb_zone_id
-    evaluate_target_health = false
-  }
-}

--- a/infrastructure/staging/pdf-generator.tf
+++ b/infrastructure/staging/pdf-generator.tf
@@ -23,13 +23,10 @@ module "pdf_generator" {
   lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
-  listener_priority = 4
+  listener_priority = 6
   hostname          = "pdf-stage"
-  domain            = local.domain
-  zone_id           = data.aws_route53_zone.external.id
-
-  # domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
-  # zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
 
   port_mappings = [{
     containerPort = 8000
@@ -43,9 +40,43 @@ module "pdf_generator" {
   }
 }
 
-
 resource "aws_iam_role_policy" "pdf_generator_read_presentation_bucket" {
   name   = "pdf-generator-stage-read-stage-presentation-bucket"
   role   = module.pdf_generator.task_role_name
   policy = data.aws_iam_policy_document.presentation_read.json
+}
+
+# DNS / ALB rules for dlcs.io (will eventually be deleted)
+resource "aws_alb_listener_rule" "pdf_stage_dlcs_io" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 4
+
+  action {
+    type             = "forward"
+    target_group_arn = module.pdf_generator.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["pdf-stage.${local.domain}"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+}
+
+resource "aws_route53_record" "pdf_stage_dlcs_io" {
+  zone_id = data.aws_route53_zone.external.id
+  name    = "pdf-stage.${local.domain}"
+  type    = "A"
+
+  alias {
+    name                   = data.terraform_remote_state.common.outputs.lb_fqdn
+    zone_id                = data.terraform_remote_state.common.outputs.lb_zone_id
+    evaluate_target_health = false
+  }
 }


### PR DESCRIPTION
Updated `wellcomecollection.digirati.io` certificate to have `dlcs.io` and `*.dlcs.io` SANs. This is an interim step to get working with CloudFront. As this will be removed in the near future I've commented out some ACM resources that will be used once we remove `dlcs.io` domains.

Updated staging and test to use new `wellcomecollection.digirati.io`  domains. Kept `*.dlcs.io` equivalents but moved to a separate file for ease of deletion.
