### PR TITLE
Temporarily increase resources to test Chemist and Druggist

### DIFF
--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -42,7 +42,8 @@ module "bastion" {
   service_security_group_ids = [aws_security_group.staging.id, aws_security_group.production.id]
   key_name                   = "iiif-builder"
   ip_whitelist = [
-    "62.254.125.26/32" # Glasgow VPN
+    "62.254.125.26/31",  # Glasgow
+    "62.254.125.28/30",  # Glasgow
   ]
 }
 

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -8,8 +8,8 @@ module "workflow_processor" {
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:staging"
 
-  cpu    = 256
-  memory = 512
+  cpu    = 4096
+  memory = 24576
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -8,8 +8,8 @@ module "workflow_processor" {
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:staging"
 
-  cpu    = 512
-  memory = 2048
+  cpu    = 256
+  memory = 512
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -8,8 +8,8 @@ module "workflow_processor" {
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:staging"
 
-  cpu    = 4096
-  memory = 24576
+  cpu    = 512
+  memory = 2048
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
@@ -86,8 +86,8 @@ module "workflow_processor_stageprod" {
 
   docker_image = "${data.terraform_remote_state.common.outputs.workflow_processor_url}:staging-prod"
 
-  cpu    = 512
-  memory = 2048
+  cpu    = 2048
+  memory = 12288
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id


### PR DESCRIPTION
4 vCPU and 24 GB of RAM to tear through C&D for testing the build process.