### PR TITLE
Split text services to separate ECS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,39 @@ Current Terraform version: 0.14.x
 
 Both Staging and Production share common infrastructure, including LoadBalancer. As such priority rules need to take into account all environments. The hostnames + priorities are:
 
-| Priority | Rule                                                             |
-|----------|------------------------------------------------------------------|
-| 1        | iiif.wellcomecollection.org/dash* -> dashboard-prod              |
-| 2        | iiif.wellcomecollection.org -> iiif-builder-prod                 |
-| 3        | iiif-stage.wellcomecollection.org/dash* -> dashboard-stage       |
-| 5        | iiif-test.wellcomecollection.org/dash* -> dashboard-stageprd     |
-| 6        | pdf-stage.wellcomecollection.digirati.io -> pdf-generator-stage  |
-| 7        | dds-stage.wellcomecollection.digirati.io -> iiif-builder-stage   |
-| 8        | dash-stage.wellcomecollection.digirati.io -> dashboard-stage     |
-| 9        | dds-test.wellcomecollection.digirati.io -> iiif-builder-stageprd |
-| 10       | dash-test.wellcomecollection.digirati.io -> dashboard-stageprd   |
-| 20       | iiif-test.wellcomecollection.org -> iiif-builder-stageprd        |
-| 21       | iiif-stage.wellcomecollection.org -> iiif-builder-stage          |
-| 23       | dds.wellcomecollection.digirati.io -> iiif-builder-prod          |
-| 24       | dash.wellcomecollection.digirati.io -> dashboard-prod            |
-| 25       | pdf.wellcomecollection.digirati.io -> pdf-generator-prod         |
+| Priority | Rule                                                                          |
+|----------|-------------------------------------------------------------------------------|
+| 1        | iiif.wellcomecollection.org/dash* -> dashboard-prod                           |
+| 3        | iiif-stage.wellcomecollection.org/dash* -> dashboard-stage                    |
+| 5        | iiif-test.wellcomecollection.org/dash* -> dashboard-stageprd                  |
+| 6        | pdf-stage.wellcomecollection.digirati.io -> pdf-generator-stage               |
+| 8        | dash-stage.wellcomecollection.digirati.io -> dashboard-stage                  |
+| 10       | dash-test.wellcomecollection.digirati.io -> dashboard-stageprd                |
+| 24       | dash.wellcomecollection.digirati.io -> dashboard-prod                         |
+| 25       | pdf.wellcomecollection.digirati.io -> pdf-generator-prod                      |
+| 30       | dds-stage.wellcomecollection.digirati.io/text* -> iiif-builder-text-stage     |
+| 31       | dds-stage.wellcomecollection.digirati.io/search* -> iiif-builder-text-stage   |
+| 32       | iiif-stage.wellcomecollection.org/text* -> iiif-builder-text-stage            |
+| 33       | iiif-stage.wellcomecollection.org/search* -> iiif-builder-text-stage          |
+| 34       | dds-test.wellcomecollection.digirati.io/text* -> iiif-builder-text-stageprd   |
+| 35       | dds-test.wellcomecollection.digirati.io/search* -> iiif-builder-text-stageprd |
+| 34       | iiif-test.wellcomecollection.org/text* -> iiif-builder-text-stageprd          |
+| 35       | iiif-test.wellcomecollection.org/search* -> iiif-builder-text-stageprd        |
 
+
+
+| 200        | iiif.wellcomecollection.org -> iiif-builder-prod                 |
+| 210        | dds-stage.wellcomecollection.digirati.io -> iiif-builder-stage   |
+| 230        | dds-test.wellcomecollection.digirati.io -> iiif-builder-stageprd |
+| 240       | iiif-test.wellcomecollection.org -> iiif-builder-stageprd        |
+| 250       | iiif-stage.wellcomecollection.org -> iiif-builder-stage          |
+| 260       | dds.wellcomecollection.digirati.io -> iiif-builder-prod          |
+
+
+|        | iiif.wellcomecollection.org -> iiif-builder-prod                 |
+|        | iiif-test.wellcomecollection.org -> iiif-builder-stageprd        |
+|        | iiif-stage.wellcomecollection.org -> iiif-builder-stage          |
+|        | dds.wellcomecollection.digirati.io -> iiif-builder-prod          |
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -37,23 +37,18 @@ Both Staging and Production share common infrastructure, including LoadBalancer.
 | 33       | iiif-stage.wellcomecollection.org/search* -> iiif-builder-text-stage          |
 | 34       | dds-test.wellcomecollection.digirati.io/text* -> iiif-builder-text-stageprd   |
 | 35       | dds-test.wellcomecollection.digirati.io/search* -> iiif-builder-text-stageprd |
-| 34       | iiif-test.wellcomecollection.org/text* -> iiif-builder-text-stageprd          |
-| 35       | iiif-test.wellcomecollection.org/search* -> iiif-builder-text-stageprd        |
-
-
-
-| 200        | iiif.wellcomecollection.org -> iiif-builder-prod                 |
-| 210        | dds-stage.wellcomecollection.digirati.io -> iiif-builder-stage   |
-| 230        | dds-test.wellcomecollection.digirati.io -> iiif-builder-stageprd |
-| 240       | iiif-test.wellcomecollection.org -> iiif-builder-stageprd        |
-| 250       | iiif-stage.wellcomecollection.org -> iiif-builder-stage          |
-| 260       | dds.wellcomecollection.digirati.io -> iiif-builder-prod          |
-
-
-|        | iiif.wellcomecollection.org -> iiif-builder-prod                 |
-|        | iiif-test.wellcomecollection.org -> iiif-builder-stageprd        |
-|        | iiif-stage.wellcomecollection.org -> iiif-builder-stage          |
-|        | dds.wellcomecollection.digirati.io -> iiif-builder-prod          |
+| 36       | iiif-test.wellcomecollection.org/text* -> iiif-builder-text-stageprd          |
+| 37       | iiif-test.wellcomecollection.org/search* -> iiif-builder-text-stageprd        |
+| 40       | dds.wellcomecollection.digirati.io/text* -> iiif-builder-text-prod            |
+| 41       | dds.wellcomecollection.digirati.io/search* -> iiif-builder-text-prod          |
+| 42       | iiif.wellcomecollection.org/text* -> iiif-builder-text-prod                   |
+| 43       | iiif.wellcomecollection.org/search* -> iiif-builder-text-prod                 |
+| 200      | iiif.wellcomecollection.org -> iiif-builder-prod                              |
+| 210      | dds-stage.wellcomecollection.digirati.io -> iiif-builder-stage                |
+| 230      | dds-test.wellcomecollection.digirati.io -> iiif-builder-stageprd              |
+| 240      | iiif-test.wellcomecollection.org -> iiif-builder-stageprd                     |
+| 250      | iiif-stage.wellcomecollection.org -> iiif-builder-stage                       |
+| 260      | dds.wellcomecollection.digirati.io -> iiif-builder-prod                       |
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Current Terraform version: 0.14.x
 
 > Note: Networking infrastructure (VPC + Subnets) are managed in the central [platform-infrastructure](https://github.com/wellcomecollection/platform-infrastructure/) repository.
 
+> Note: AWS account root is granted access to Wellcome storage buckets in [storage-service](https://github.com/wellcomecollection/storage-service/) repository.
+
 ## Table of Contents
 
 * [common](/infrastructure/common/readme.md)

--- a/infrastructure/modules/ecs/web/main.tf
+++ b/infrastructure/modules/ecs/web/main.tf
@@ -118,6 +118,7 @@ resource "aws_alb_listener_rule" "https" {
 }
 
 resource "aws_route53_record" "service" {
+  count   = var.create_dns ? 1 : 0
   zone_id = var.zone_id
   name    = "${var.hostname}.${var.domain}"
   type    = "A"

--- a/infrastructure/modules/ecs/web/outputs.tf
+++ b/infrastructure/modules/ecs/web/outputs.tf
@@ -6,7 +6,7 @@ output "task_role_arn" {
   value = module.task_definition.task_role_arn
 }
 
-output "service_target_group_arn"{
+output "service_target_group_arn" {
   value = aws_alb_target_group.service.arn
 }
 

--- a/infrastructure/modules/ecs/web/variables.tf
+++ b/infrastructure/modules/ecs/web/variables.tf
@@ -59,9 +59,15 @@ variable "lb_listener_arn" {
 }
 
 variable "lb_zone_id" {
+  description = "ZoneId for loadbalancer, used for dns entries"
+  type        = string
+  default     = ""
 }
 
 variable "lb_fqdn" {
+  description = "FQDN for loadbalancer, used for dns entries"
+  type        = string
+  default     = ""
 }
 
 variable "path_patterns" {
@@ -78,14 +84,18 @@ variable "listener_priority" {
 
 variable "hostname" {
   description = "Hostname to register in Route53"
+  type        = string
+  default     = ""
 }
 
 variable "domain" {
-  description = "Main domain"
+  description = "Main domain for listener"
 }
 
 variable "zone_id" {
   description = "Route53 zone Id"
+  type        = string
+  default     = ""
 }
 
 variable "port_mappings" {
@@ -108,4 +118,9 @@ variable "env_vars" {
   description = "Variables to be set as environment variables"
   type        = map(string)
   default     = {}
+}
+
+variable "create_dns" {
+  description = "Whether to create route53 dns entry for"
+  default     = true
 }

--- a/infrastructure/production/iiif-builder-text.tf
+++ b/infrastructure/production/iiif-builder-text.tf
@@ -22,7 +22,7 @@ module "iiif_builder_text" {
   lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
 
   listener_priority = 40
-  path_patterns     = ["/text*", "search/*"]
+  path_patterns     = ["/text*", "/search*"]
   hostname          = "dds"
   domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
   create_dns        = false
@@ -38,6 +38,8 @@ module "iiif_builder_text" {
     ConnectionStrings__Dds                = "iiif-builder/production/dds-connstr"
     Storage__ClientId                     = "iiif-builder/common/storage/clientid"
     Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+    Dlcs__ApiKey                          = "iiif-builder/common/dlcs-apikey"
+    Dlcs__ApiSecret                       = "iiif-builder/common/dlcs-apisecret"
   }
 
   env_vars = {
@@ -45,6 +47,13 @@ module "iiif_builder_text" {
     "FeatureManagement__TextServices"         = "True"
     "FeatureManagement__PresentationServices" = "False"
   }
+}
+
+# wellcome-collection production storage bucket (in diff aws account)
+resource "aws_iam_role_policy" "iiifbuilder_text_read_wellcomecollection_storage_bucket" {
+  name   = "iiifbuilder-text-read-wellcomecollection-storage-bucket"
+  role   = module.iiif_builder_text.task_role_name
+  policy = data.aws_iam_policy_document.wellcomecollection_storage_bucket_read.json
 }
 
 resource "aws_iam_role_policy" "iiifbuilder_text_readwrite_storagemaps_bucket" {

--- a/infrastructure/production/iiif-builder-text.tf
+++ b/infrastructure/production/iiif-builder-text.tf
@@ -1,0 +1,60 @@
+# IIIF-Builder app for /search and /text
+module "iiif_builder_text" {
+  source = "../modules/ecs/web"
+
+  name        = "iiif-builder-text"
+  environment = local.environment
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
+
+  docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:production"
+  container_port = 80
+
+  cpu    = 512
+  memory = 3072
+
+  ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
+  service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
+  service_security_group_ids     = [data.terraform_remote_state.common.outputs.production_security_group_id, ]
+
+  healthcheck_path = "/management/healthcheck"
+
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+
+  listener_priority = 40
+  path_patterns     = ["/text*", "search/*"]
+  hostname          = "dds"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  create_dns        = false
+
+  port_mappings = [{
+    containerPort = 80
+    hostPort      = 80
+    protocol      = "tcp"
+  }]
+
+  secret_env_vars = {
+    ConnectionStrings__DdsInstrumentation = "iiif-builder/production/ddsinstrumentation-connstr"
+    ConnectionStrings__Dds                = "iiif-builder/production/dds-connstr"
+    Storage__ClientId                     = "iiif-builder/common/storage/clientid"
+    Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+  }
+
+  env_vars = {
+    "ASPNETCORE_ENVIRONMENT" = "Production"
+    "FeatureManagement__TextServices"         = "True"
+    "FeatureManagement__PresentationServices" = "False"
+  }
+}
+
+resource "aws_iam_role_policy" "iiifbuilder_text_readwrite_storagemaps_bucket" {
+  name   = "iiifbuilder-text-readwrite-storagemaps-bucket"
+  role   = module.iiif_builder_text.task_role_name
+  policy = data.aws_iam_policy_document.storagemaps_readwrite.json
+}
+
+resource "aws_iam_role_policy" "iiifbuilder_text_read_text_bucket" {
+  name   = "iiifbuilder-text-read-text-bucket"
+  role   = module.iiif_builder_text.task_role_name
+  policy = data.aws_iam_policy_document.text_read.json
+}

--- a/infrastructure/production/iiif-builder.tf
+++ b/infrastructure/production/iiif-builder.tf
@@ -10,7 +10,7 @@ module "iiif_builder" {
   container_port = 80
 
   cpu    = 512
-  memory = 1024
+  memory = 2048
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id

--- a/infrastructure/production/iiif-builder.tf
+++ b/infrastructure/production/iiif-builder.tf
@@ -9,8 +9,8 @@ module "iiif_builder" {
   docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:production"
   container_port = 80
 
-  cpu    = 256
-  memory = 512
+  cpu    = 512
+  memory = 1024
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
@@ -23,7 +23,7 @@ module "iiif_builder" {
   lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
-  listener_priority = 23
+  listener_priority = 260
   hostname          = "dds"
   domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
   zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
@@ -49,6 +49,8 @@ module "iiif_builder" {
 
   env_vars = {
     "ASPNETCORE_ENVIRONMENT" = "Production"
+    "FeatureManagement__TextServices"         = "False"
+    "FeatureManagement__PresentationServices" = "True"
   }
 }
 
@@ -69,12 +71,6 @@ resource "aws_iam_role_policy" "iiifbuilder_read_presentation_bucket" {
   name   = "iiifbuilder-read-presentation-bucket"
   role   = module.iiif_builder.task_role_name
   policy = data.aws_iam_policy_document.presentation_read.json
-}
-
-resource "aws_iam_role_policy" "iiifbuilder_read_text_bucket" {
-  name   = "iiifbuilder-read-text-bucket"
-  role   = module.iiif_builder.task_role_name
-  policy = data.aws_iam_policy_document.text_read.json
 }
 
 resource "aws_iam_role_policy" "iiifbuilder_read_anno_bucket" {

--- a/infrastructure/production/listener_rules.tf
+++ b/infrastructure/production/listener_rules.tf
@@ -1,4 +1,5 @@
 # requests are forwarded via Wellcome's CloudFront so will come in with different hostname
+# this is only required if 'All' or 'Host' is whitelisted, which is the case for dash + dds
 
 # iiif.wellcomecollection.org/dash* -> dashboard
 resource "aws_alb_listener_rule" "wc_dash" {

--- a/infrastructure/production/listener_rules.tf
+++ b/infrastructure/production/listener_rules.tf
@@ -27,7 +27,7 @@ resource "aws_alb_listener_rule" "wc_dash" {
 # iiif.wellcomecollection.org/* -> iiifbuilder
 resource "aws_alb_listener_rule" "wc_iiifbuilder" {
   listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
-  priority     = 2
+  priority     = 200
 
   action {
     type             = "forward"
@@ -43,6 +43,52 @@ resource "aws_alb_listener_rule" "wc_iiifbuilder" {
   condition {
     path_pattern {
       values = ["/*"]
+    }
+  }
+}
+
+# iiif.wellcomecollection.org/text* -> iiifbuilder
+resource "aws_alb_listener_rule" "wc_text" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 42
+
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder_text.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["iiif.wellcomecollection.org"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/text*"]
+    }
+  }
+}
+
+# iiif.wellcomecollection.org/search* -> iiifbuilder
+resource "aws_alb_listener_rule" "wc_search" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 43
+
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder_text.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["iiif.wellcomecollection.org"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/search*"]
     }
   }
 }

--- a/infrastructure/production/s3.tf
+++ b/infrastructure/production/s3.tf
@@ -1,4 +1,4 @@
-# access to wellcome-collection storage. Needs corresponding perms in wellcome account
+# access to wellcome-collection storage. 
 data "aws_iam_policy_document" "wellcomecollection_storage_bucket_read" {
   statement {
     actions = [
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "wellcomecollection_storage_bucket_read" {
   }
 }
 
-# access to wellcome-collection storage. Needs corresponding perms in wellcome account
+# access to wellcome-collection storage.
 data "aws_iam_policy_document" "wellcomecollection_storage_staging_bucket_read" {
   statement {
     actions = [

--- a/infrastructure/staging/iiif-builder-text.tf
+++ b/infrastructure/staging/iiif-builder-text.tf
@@ -1,0 +1,135 @@
+# IIIF-Builder-text app
+module "iiif_builder_text" {
+  source = "../modules/ecs/web"
+
+  name        = "iiif-builder-text"
+  environment = local.environment
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
+
+  docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:staging"
+  container_port = 80
+
+  cpu    = 512
+  memory = 2048
+
+  ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
+  service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
+  service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
+
+  healthcheck_path = "/management/healthcheck"
+
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+
+  listener_priority = 30
+  path_patterns     = ["/text*", "search/*"]
+  hostname          = "dds-stage"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  create_dns        = false
+
+  port_mappings = [{
+    containerPort = 80
+    hostPort      = 80
+    protocol      = "tcp"
+  }]
+
+  secret_env_vars = {
+    ConnectionStrings__DdsInstrumentation = "iiif-builder/staging/ddsinstrumentation-connstr"
+    ConnectionStrings__Dds                = "iiif-builder/staging/dds-connstr"
+    Storage__ClientId                     = "iiif-builder/common/storage/clientid"
+    Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+  }
+
+  env_vars = {
+    "ASPNETCORE_ENVIRONMENT"                  = "Staging"
+    "FeatureManagement__TextServices"         = "True"
+    "FeatureManagement__PresentationServices" = "False"
+  }
+}
+
+module "iiif_builder_text_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.iiif_builder_text.service_name
+}
+
+resource "aws_iam_role_policy" "iiifbuilder_text_readwrite_storagemaps_bucket" {
+  name   = "iiifbuilder-text-stage-readwrite-stage-storagemaps-bucket"
+  role   = module.iiif_builder_text.task_role_name
+  policy = data.aws_iam_policy_document.storagemaps_readwrite.json
+}
+
+resource "aws_iam_role_policy" "iiifbuilder_text_read_text_bucket" {
+  name   = "iiifbuilder-text-stage-read-stage-text-bucket"
+  role   = module.iiif_builder_text.task_role_name
+  policy = data.aws_iam_policy_document.text_read.json
+}
+
+# IIIF-Builder, staging hosted pointing at Prod storage
+module "iiif_builder_text_stageprod" {
+  source = "../modules/ecs/web"
+
+  name        = "iiif-builder-text"
+  environment = local.environment_alt
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
+
+  docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:staging-prod"
+  container_port = 80
+
+  cpu    = 512
+  memory = 3072
+
+  ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
+  service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
+  service_subnets                = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
+  service_security_group_ids     = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
+
+  healthcheck_path = "/management/healthcheck"
+
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+
+  listener_priority = 34
+  path_patterns     = ["/text*", "search/*"]
+  hostname          = "dds-test"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  create_dns        = false
+
+  port_mappings = [{
+    containerPort = 80
+    hostPort      = 80
+    protocol      = "tcp"
+  }]
+
+  secret_env_vars = {
+    ConnectionStrings__DdsInstrumentation = "iiif-builder/staging/ddsinstrumentationstgprd-connstr"
+    ConnectionStrings__Dds                = "iiif-builder/staging/ddsstgprd-connstr"
+    Storage__ClientId                     = "iiif-builder/common/storage/clientid"
+    Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+  }
+
+  env_vars = {
+    "ASPNETCORE_ENVIRONMENT"                  = "Staging-Prod"
+    "FeatureManagement__TextServices"         = "True"
+    "FeatureManagement__PresentationServices" = "False"
+  }
+}
+
+module "iiif_builder_text_stageprod_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.iiif_builder_text_stageprod.service_name
+}
+
+resource "aws_iam_role_policy" "iiifbuilderstgprd_text_readwrite_storagemaps_bucket" {
+  name   = "iiifbuilder-text-stageprd-readwrite-stage-storagemaps-bucket"
+  role   = module.iiif_builder_text_stageprod.task_role_name
+  policy = data.aws_iam_policy_document.storagemaps_readwrite.json
+}
+
+resource "aws_iam_role_policy" "iiifbuilderstgprd_text_read_text_bucket" {
+  name   = "iiifbuilder-text-stageprd-read-stage-text-bucket"
+  role   = module.iiif_builder_text_stageprod.task_role_name
+  policy = data.aws_iam_policy_document.text_read.json
+}

--- a/infrastructure/staging/iiif-builder-text.tf
+++ b/infrastructure/staging/iiif-builder-text.tf
@@ -78,7 +78,7 @@ module "iiif_builder_text_stageprod" {
   container_port = 80
 
   cpu    = 512
-  memory = 3072
+  memory = 1024
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id

--- a/infrastructure/staging/iiif-builder-text.tf
+++ b/infrastructure/staging/iiif-builder-text.tf
@@ -22,7 +22,7 @@ module "iiif_builder_text" {
   lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
 
   listener_priority = 30
-  path_patterns     = ["/text*", "search/*"]
+  path_patterns     = ["/text*", "/search*"]
   hostname          = "dds-stage"
   domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
   create_dns        = false
@@ -38,6 +38,8 @@ module "iiif_builder_text" {
     ConnectionStrings__Dds                = "iiif-builder/staging/dds-connstr"
     Storage__ClientId                     = "iiif-builder/common/storage/clientid"
     Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+    Dlcs__ApiKey                          = "iiif-builder/common/dlcs-apikey"
+    Dlcs__ApiSecret                       = "iiif-builder/common/dlcs-apisecret"
   }
 
   env_vars = {
@@ -52,6 +54,13 @@ module "iiif_builder_text_scaling" {
 
   cluster_name = aws_ecs_cluster.iiif_builder.name
   service_name = module.iiif_builder_text.service_name
+}
+
+# wellcome-collection staging storage bucket (in diff aws account)
+resource "aws_iam_role_policy" "iiifbuilder_text_read_wellcomecollection_storage_staging_bucket" {
+  name   = "iiifbuilder-text-stage-read-wellcomecollection-storage-staging-bucket"
+  role   = module.iiif_builder_text.task_role_name
+  policy = data.aws_iam_policy_document.wellcomecollection_storage_staging_bucket_read.json
 }
 
 resource "aws_iam_role_policy" "iiifbuilder_text_readwrite_storagemaps_bucket" {
@@ -90,7 +99,7 @@ module "iiif_builder_text_stageprod" {
   lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
 
   listener_priority = 34
-  path_patterns     = ["/text*", "search/*"]
+  path_patterns     = ["/text*", "/search*"]
   hostname          = "dds-test"
   domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
   create_dns        = false
@@ -106,6 +115,8 @@ module "iiif_builder_text_stageprod" {
     ConnectionStrings__Dds                = "iiif-builder/staging/ddsstgprd-connstr"
     Storage__ClientId                     = "iiif-builder/common/storage/clientid"
     Storage__ClientSecret                 = "iiif-builder/common/storage/clientsecret"
+    Dlcs__ApiKey                          = "iiif-builder/common/dlcs-apikey"
+    Dlcs__ApiSecret                       = "iiif-builder/common/dlcs-apisecret"
   }
 
   env_vars = {
@@ -120,6 +131,13 @@ module "iiif_builder_text_stageprod_scaling" {
 
   cluster_name = aws_ecs_cluster.iiif_builder.name
   service_name = module.iiif_builder_text_stageprod.service_name
+}
+
+# wellcome-collection staging storage bucket (in diff aws account)
+resource "aws_iam_role_policy" "iiifbuilderstgprd_text_read_wellcomecollection_storage_staging_bucket" {
+  name   = "iiifbuilder-text-stageprd-read-wellcomecollection-storage-staging-bucket"
+  role   = module.iiif_builder_text_stageprod.task_role_name
+  policy = data.aws_iam_policy_document.wellcomecollection_storage_bucket_read.json
 }
 
 resource "aws_iam_role_policy" "iiifbuilderstgprd_text_readwrite_storagemaps_bucket" {

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -9,8 +9,8 @@ module "iiif_builder" {
   docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:staging"
   container_port = 80
 
-  cpu    = 512
-  memory = 3072
+  cpu    = 256
+  memory = 512
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
@@ -23,7 +23,7 @@ module "iiif_builder" {
   lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
-  listener_priority = 7
+  listener_priority = 210
   hostname          = "dds-stage"
   domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
   zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
@@ -48,7 +48,9 @@ module "iiif_builder" {
   }
 
   env_vars = {
-    "ASPNETCORE_ENVIRONMENT" = "Staging"
+    "ASPNETCORE_ENVIRONMENT"                  = "Staging"
+    "FeatureManagement__TextServices"         = "False"
+    "FeatureManagement__PresentationServices" = "True"
   }
 }
 
@@ -78,12 +80,6 @@ resource "aws_iam_role_policy" "iiifbuilder_read_presentation_bucket" {
   policy = data.aws_iam_policy_document.presentation_read.json
 }
 
-resource "aws_iam_role_policy" "iiifbuilder_read_text_bucket" {
-  name   = "iiifbuilder-stage-read-stage-text-bucket"
-  role   = module.iiif_builder.task_role_name
-  policy = data.aws_iam_policy_document.text_read.json
-}
-
 resource "aws_iam_role_policy" "iiifbuilder_read_anno_bucket" {
   name   = "iiifbuilder-stage-read-stage-anno-bucket"
   role   = module.iiif_builder.task_role_name
@@ -102,8 +98,8 @@ module "iiif_builder_stageprod" {
   docker_image   = "${data.terraform_remote_state.common.outputs.iiif_builder_url}:staging-prod"
   container_port = 80
 
-  cpu    = 512
-  memory = 3072
+  cpu    = 256
+  memory = 512
 
   ecs_cluster_arn                = aws_ecs_cluster.iiif_builder.arn
   service_discovery_namespace_id = data.terraform_remote_state.common.outputs.service_discovery_namespace_id
@@ -116,7 +112,7 @@ module "iiif_builder_stageprod" {
   lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
   lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
 
-  listener_priority = 9
+  listener_priority = 230
   hostname          = "dds-test"
   domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
   zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
@@ -141,7 +137,9 @@ module "iiif_builder_stageprod" {
   }
 
   env_vars = {
-    "ASPNETCORE_ENVIRONMENT" = "Staging-Prod"
+    "ASPNETCORE_ENVIRONMENT"                  = "Staging-Prod"
+    "FeatureManagement__TextServices"         = "False"
+    "FeatureManagement__PresentationServices" = "True"
   }
 }
 
@@ -170,12 +168,6 @@ resource "aws_iam_role_policy" "iiifbuilderstgprd_read_presentation_bucket" {
   name   = "iiifbuilder-stageprd-read-stage-presentation-bucket"
   role   = module.iiif_builder_stageprod.task_role_name
   policy = data.aws_iam_policy_document.presentation_read.json
-}
-
-resource "aws_iam_role_policy" "iiifbuilderstgprd_read_text_bucket" {
-  name   = "iiifbuilder-stageprd-read-stage-text-bucket"
-  role   = module.iiif_builder_stageprod.task_role_name
-  policy = data.aws_iam_policy_document.text_read.json
 }
 
 resource "aws_iam_role_policy" "iiifbuilderstgprd_read_anno_bucket" {

--- a/infrastructure/staging/listener_rules.tf
+++ b/infrastructure/staging/listener_rules.tf
@@ -1,4 +1,5 @@
 # requests are forwarded via Wellcome's CloudFront so will come in with different hostname
+# this is only required if 'All' or 'Host' is whitelisted, which is the case for dash + dds
 
 # iiif-stage.wellcomecollection.org/dash* -> dashboard-stage
 resource "aws_alb_listener_rule" "wc_dash_stage" {
@@ -26,7 +27,7 @@ resource "aws_alb_listener_rule" "wc_dash_stage" {
 # iiif-stage.wellcomecollection.org/* -> iiifbuilder-stage
 resource "aws_alb_listener_rule" "wc_iiifbuilder_stage" {
   listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
-  priority     = 21
+  priority     = 250
 
   action {
     type             = "forward"
@@ -42,6 +43,52 @@ resource "aws_alb_listener_rule" "wc_iiifbuilder_stage" {
   condition {
     path_pattern {
       values = ["/*"]
+    }
+  }
+}
+
+# iiif-stage.wellcomecollection.org/text* -> iiifbuilder-text-stage
+resource "aws_alb_listener_rule" "wc_text_stage" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 32
+
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder_text.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["iiif-stage.wellcomecollection.org"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/text*"]
+    }
+  }
+}
+
+# iiif-stage.wellcomecollection.org/search* -> iiifbuilder-text-stage
+resource "aws_alb_listener_rule" "wc_search_stage" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 33
+
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder_text.service_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["iiif-stage.wellcomecollection.org"]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/search*"]
     }
   }
 }
@@ -72,7 +119,7 @@ resource "aws_alb_listener_rule" "wc_dash_stageprd" {
 # iiif-test.wellcomecollection.org/* -> iiifbuilder-stgprd
 resource "aws_alb_listener_rule" "wc_iiifbuilder_stageprd" {
   listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
-  priority     = 20
+  priority     = 240
 
   action {
     type             = "forward"
@@ -92,48 +139,48 @@ resource "aws_alb_listener_rule" "wc_iiifbuilder_stageprd" {
   }
 }
 
-# # iiif-test.wellcomecollection.org/pdf-cover* -> pdf-generator-stage
-# resource "aws_alb_listener_rule" "wc_pdfcover_test" {
-#   listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
-#   priority     = 23
+# iiif-test.wellcomecollection.org/text* -> iiifbuilder-text-test
+resource "aws_alb_listener_rule" "wc_text_stageprd" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 36
 
-#   action {
-#     type             = "forward"
-#     target_group_arn = module.pdf_generator.service_target_group_arn
-#   }
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder_text_stageprod.service_target_group_arn
+  }
 
-#   condition {
-#     host_header {
-#       values = ["iiif-test.wellcomecollection.org"]
-#     }
-#   }
+  condition {
+    host_header {
+      values = ["iiif-test.wellcomecollection.org"]
+    }
+  }
 
-#   condition {
-#     path_pattern {
-#       values = ["/pdf-cover*"]
-#     }
-#   }
-# }
+  condition {
+    path_pattern {
+      values = ["/text*"]
+    }
+  }
+}
 
-# # iiif-stage.wellcomecollection.org/pdf-cover* -> pdf-generator-stage
-# resource "aws_alb_listener_rule" "wc_pdfcover_stage" {
-#   listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
-#   priority     = 24
+# iiif-test.wellcomecollection.org/search* -> iiifbuilder-text-test
+resource "aws_alb_listener_rule" "wc_search_stageprd" {
+  listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  priority     = 37
 
-#   action {
-#     type             = "forward"
-#     target_group_arn = module.pdf_generator.service_target_group_arn
-#   }
+  action {
+    type             = "forward"
+    target_group_arn = module.iiif_builder_text_stageprod.service_target_group_arn
+  }
 
-#   condition {
-#     host_header {
-#       values = ["iiif-stage.wellcomecollection.org"]
-#     }
-#   }
+  condition {
+    host_header {
+      values = ["iiif-test.wellcomecollection.org"]
+    }
+  }
 
-#   condition {
-#     path_pattern {
-#       values = ["/pdf-cover*"]
-#     }
-#   }
-# }
+  condition {
+    path_pattern {
+      values = ["/search*"]
+    }
+  }
+}

--- a/infrastructure/staging/s3.tf
+++ b/infrastructure/staging/s3.tf
@@ -1,4 +1,4 @@
-# access to wellcome-collection storage. Needs corresponding perms in wellcome account
+# access to wellcome-collection storage.
 data "aws_iam_policy_document" "wellcomecollection_storage_bucket_read" {
   statement {
     actions = [
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "wellcomecollection_storage_bucket_read" {
   }
 }
 
-# access to wellcome-collection storage. Needs corresponding perms in wellcome account
+# access to wellcome-collection storage.
 data "aws_iam_policy_document" "wellcomecollection_storage_staging_bucket_read" {
   statement {
     actions = [


### PR DESCRIPTION
DDS Server `/text` and `/search` are now handled by separate services. This PR adds ECS service for test/stage/prod and listener rules for wc.org routes.

I removed S3 text-bucket read permissions from presentation DDS server (I _think_ this is correct).

Dropped stage + test presentation DDS cpu + memory (they were previously increased for C&D).
Increased cpu + mem for prod presentation DDS