### PR TITLE
Cloudfront invalidate

### DIFF
--- a/infrastructure/common/data.tf
+++ b/infrastructure/common/data.tf
@@ -9,5 +9,7 @@ data "terraform_remote_state" "platform_infra" {
     key      = "terraform/platform-infrastructure/accounts/digirati.tfstate"
     region   = "eu-west-1"
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    profile = "wellcome-az"
   }
 }

--- a/infrastructure/common/terraform.tf
+++ b/infrastructure/common/terraform.tf
@@ -4,6 +4,8 @@ provider "aws" {
   }
 
   region = var.region
+
+  profile = "wcdev"
 }
 
 terraform {
@@ -15,6 +17,8 @@ terraform {
     region = "eu-west-1"
 
     role_arn = "arn:aws:iam::653428163053:role/digirati-developer"
+
+    profile = "wcdev"
   }
 
   required_providers {

--- a/infrastructure/production/data.tf
+++ b/infrastructure/production/data.tf
@@ -6,6 +6,8 @@ data "terraform_remote_state" "common" {
     bucket = "dlcs-remote-state"
     key    = "iiif-builder/common/terraform.tfstate"
     region = "eu-west-1"
+
+    profile = "wcdev"
   }
 }
 
@@ -19,5 +21,7 @@ data "terraform_remote_state" "platform_infra" {
     key      = "terraform/platform-infrastructure/accounts/digirati.tfstate"
     region   = "eu-west-1"
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    profile = "wellcome-az"
   }
 }

--- a/infrastructure/production/sns.tf
+++ b/infrastructure/production/sns.tf
@@ -1,0 +1,26 @@
+data "aws_sns_topic" "iiif_invalidate_cache" {
+  provider = aws.storage
+
+  name = "iiif-prod-cloudfront-invalidate"
+}
+
+data "aws_sns_topic" "api_invalidate_cache" {
+  provider = aws.storage
+
+  name = "api-prod-cloudfront-invalidate"
+}
+
+# access to SNS topics for iiif.wc.org + api.wc.org cache-invalidation
+data "aws_iam_policy_document" "invalidate_cache_publish" {
+  statement {
+    actions = [
+      "sns:Publish",
+      "sns:SendMessage",
+    ]
+
+    resources = [
+      data.aws_sns_topic.iiif_invalidate_cache.arn,
+      data.aws_sns_topic.api_invalidate_cache.arn
+    ]
+  }
+}

--- a/infrastructure/production/terraform.tf
+++ b/infrastructure/production/terraform.tf
@@ -3,7 +3,20 @@ provider "aws" {
     role_arn = "arn:aws:iam::653428163053:role/digirati-developer"
   }
 
-  region  = var.region
+  region = var.region
+
+  profile = "wcdev"
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+  }
+
+  alias  = "storage"
+  region = var.region
+
+  profile = "wellcome-az"
 }
 
 terraform {

--- a/infrastructure/production/terraform.tf
+++ b/infrastructure/production/terraform.tf
@@ -28,6 +28,8 @@ terraform {
     region = "eu-west-1"
 
     role_arn = "arn:aws:iam::653428163053:role/digirati-developer"
+
+    profile = "wcdev"
   }
 
   required_providers {

--- a/infrastructure/staging/data.tf
+++ b/infrastructure/staging/data.tf
@@ -6,6 +6,8 @@ data "terraform_remote_state" "common" {
     bucket = "dlcs-remote-state"
     key    = "iiif-builder/common/terraform.tfstate"
     region = "eu-west-1"
+
+    profile = "wcdev"
   }
 }
 
@@ -19,5 +21,7 @@ data "terraform_remote_state" "platform_infra" {
     key      = "terraform/platform-infrastructure/accounts/digirati.tfstate"
     region   = "eu-west-1"
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    profile = "wellcome-az"
   }
 }

--- a/infrastructure/staging/sns.tf
+++ b/infrastructure/staging/sns.tf
@@ -1,0 +1,59 @@
+data "aws_sns_topic" "iiif_test_invalidate_cache" {
+  provider = aws.storage
+
+  name = "iiif-test-cloudfront-invalidate"
+}
+
+data "aws_sns_topic" "iiif_stage_invalidate_cache" {
+  provider = aws.storage
+
+  name = "iiif-stage-cloudfront-invalidate"
+}
+
+data "aws_sns_topic" "api_stage_invalidate_cache" {
+  provider = aws.storage
+
+  name = "api-stage-cloudfront-invalidate"
+}
+
+# access to SNS topic for iiif-test.wc.org cache-invalidation
+data "aws_iam_policy_document" "iiif_test_invalidate_cache_publish" {
+  statement {
+    actions = [
+      "sns:Publish",
+      "sns:SendMessage",
+    ]
+
+    resources = [
+      data.aws_sns_topic.iiif_test_invalidate_cache.arn
+    ]
+  }
+}
+
+# access to SNS topic for iiif-stage.wc.org cache-invalidation
+data "aws_iam_policy_document" "iiif_stage_invalidate_cache_publish" {
+  statement {
+    actions = [
+      "sns:Publish",
+      "sns:SendMessage",
+    ]
+
+    resources = [
+      data.aws_sns_topic.iiif_stage_invalidate_cache.arn
+    ]
+  }
+}
+
+# access to SNS topic for api-stage.wc.org cache-invalidation
+data "aws_iam_policy_document" "api_stage_invalidate_cache_publish" {
+  statement {
+    actions = [
+      "sns:Publish",
+      "sns:SendMessage",
+    ]
+
+    resources = [
+      data.aws_sns_topic.api_stage_invalidate_cache.arn
+    ]
+  }
+}

--- a/infrastructure/staging/terraform.tf
+++ b/infrastructure/staging/terraform.tf
@@ -3,7 +3,20 @@ provider "aws" {
     role_arn = "arn:aws:iam::653428163053:role/digirati-developer"
   }
 
-  region  = var.region
+  region = var.region
+
+  profile = "wcdev"
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+  }
+
+  alias  = "storage"
+  region = var.region
+
+  profile = "wellcome-az"
 }
 
 terraform {

--- a/infrastructure/staging/terraform.tf
+++ b/infrastructure/staging/terraform.tf
@@ -28,6 +28,8 @@ terraform {
     region = "eu-west-1"
 
     role_arn = "arn:aws:iam::653428163053:role/digirati-developer"
+
+    profile = "wcdev"
   }
 
   required_providers {


### PR DESCRIPTION
Update workflow processors to give permissions to execute SNS topics for invalidating CloudFront caches. 

These are symmetrical permissions for those granted in https://github.com/wellcomecollection/platform-infrastructure/pull/153

Also set arn's of topics in config settings.