### PR TITLE
Add auth-test app

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Both Staging and Production share common infrastructure, including LoadBalancer.
 | 41       | dds.wellcomecollection.digirati.io/search* -> iiif-builder-text-prod          |
 | 42       | iiif.wellcomecollection.org/text* -> iiif-builder-text-prod                   |
 | 43       | iiif.wellcomecollection.org/search* -> iiif-builder-text-prod                 |
+| 60       | auth-test.wellcomecollection.digirati.io -> auth-test-stage                   |
 | 200      | iiif.wellcomecollection.org -> iiif-builder-prod                              |
 | 210      | dds-stage.wellcomecollection.digirati.io -> iiif-builder-stage                |
 | 230      | dds-test.wellcomecollection.digirati.io -> iiif-builder-stageprd              |

--- a/infrastructure/staging/auth.tf
+++ b/infrastructure/staging/auth.tf
@@ -1,0 +1,55 @@
+resource "aws_ecr_repository" "auth" {
+  name = "iiif-builder-auth"
+  tags = {
+    Terraform = true
+    Project   = "iiif-builder"
+  }
+}
+
+# Auth Test app
+module "auth_test" {
+  source = "../modules/ecs/web"
+
+  name        = "auth-test"
+  environment = local.environment
+  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
+
+  docker_image   = "${aws_ecr_repository.auth.repository_url}:test"
+  container_port = 80
+
+  cpu    = 256
+  memory = 512
+
+  ecs_cluster_arn            = aws_ecs_cluster.iiif_builder.arn
+  service_subnets            = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
+  service_security_group_ids = [data.terraform_remote_state.common.outputs.staging_security_group_id, ]
+
+  healthcheck_path = "/mappings"
+
+  lb_listener_arn = data.terraform_remote_state.common.outputs.lb_listener_arn
+  lb_zone_id      = data.terraform_remote_state.common.outputs.lb_zone_id
+  lb_fqdn         = data.terraform_remote_state.common.outputs.lb_fqdn
+
+  listener_priority = 60
+  hostname          = "auth-test"
+  domain            = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io
+  zone_id           = data.terraform_remote_state.common.outputs.wellcomecollection_digirati_io_zone_id
+
+  port_mappings = [{
+    containerPort = 80
+    hostPort      = 80
+    protocol      = "tcp"
+  }]
+
+  secret_env_vars = {
+    Auth0__Domain   = "iiif-builder/staging/auth0-domain"
+    Auth0__ClientId = "iiif-builder/staging/auth0-clientid"
+  }
+}
+
+module "auth_test_scaling" {
+  source = "../modules/autoscaling/scheduled"
+
+  cluster_name = aws_ecs_cluster.iiif_builder.name
+  service_name = module.auth_test.service_name
+}

--- a/infrastructure/staging/readme.md
+++ b/infrastructure/staging/readme.md
@@ -19,3 +19,5 @@ Uses Staging database, DLCS and Storage API.
 ### Staging-Prod
 
 Uses Staging database, DLCS and _production_ Storage API. Hostnames use `test` for this environment.
+
+`auth-test.wellcomecollection.digirati.io` is only on staging-prod environment as there is only 1 Sierra instance containing users.

--- a/infrastructure/staging/sqs.tf
+++ b/infrastructure/staging/sqs.tf
@@ -6,7 +6,7 @@ data "aws_sns_topic" "registered_bag_notification" {
 
 resource "aws_sqs_queue" "registered_bag_queue" {
   name = "wellcomecollection-stage-registered-bag-notification"
-  
+
   message_retention_seconds = 1209600 # 14 days
 }
 


### PR DESCRIPTION
New ECS service to run basic auth app, from https://github.com/wellcomecollection/iiif-builder/pull/180