### PR TITLE
Upgrade Postgres databases to latest minor version

### DIFF
--- a/infrastructure/modules/rds/main.tf
+++ b/infrastructure/modules/rds/main.tf
@@ -28,8 +28,8 @@ data "aws_secretsmanager_secret_version" "admin_creds" {
 
 resource "aws_db_instance" "postgres" {
   engine                     = "postgres"
-  engine_version             = "12.3"
-  identifier                 = local.full_name
+  engine_version             = var.db_engine_version
+  identifier                 = "${local.full_name}${var.identifier_postfix}"
   instance_class             = var.db_instance_class
   allocated_storage          = var.db_storage
   username                   = jsondecode(data.aws_secretsmanager_secret_version.admin_creds.secret_string)["admin_username"]

--- a/infrastructure/modules/rds/variables.tf
+++ b/infrastructure/modules/rds/variables.tf
@@ -46,3 +46,15 @@ variable "db_security_group_ids" {
   type        = list(string)
   description = ""
 }
+
+variable "db_engine_version" {
+  type        = string
+  description = "Postgres version to use"
+  default     = "12.3"
+}
+
+variable "identifier_postfix" {
+  type        = string
+  description = "Postfix to add to DB name, useful when doing rolling updates"
+  default     = ""
+}

--- a/infrastructure/production/main.tf
+++ b/infrastructure/production/main.tf
@@ -3,13 +3,16 @@ data "aws_subnet" "private_subnets" {
   id       = each.value
 }
 
+# NOTE: Connstr is _not_ updated automatically to keep out of state. Need to update appropriate secret
 module "rds" {
   source = "../modules/rds"
 
-  name        = local.name
-  environment = local.environment
-  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
+  name               = local.name
+  environment        = local.environment
+  identifier_postfix = "-1"
+  vpc_id             = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
+  db_engine_version = "12.10"
   db_instance_class = "db.m4.large"
   db_storage        = 250
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets

--- a/infrastructure/production/readme.md
+++ b/infrastructure/production/readme.md
@@ -1,3 +1,3 @@
-# Staging
+# Production
 
 Infrastructure for IIIF-Builder Production environment

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -10,6 +10,7 @@ module "rds" {
   environment = local.environment
   vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
+  db_engine_version = "12.10"
   db_instance_class = "db.m4.large"
   db_storage        = 250
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets


### PR DESCRIPTION
Change applied for staging and will take place at next maintenance window.

Did a rolling update with Production to avoid downtime. Not shown are some interim steps, this was partially complicated as RDS is provisioned from within a module. Outline of steps below, these happened after backing up and restoring database to new instance:

```bash
# temporarily move RDS resources out of module (added TF resource blocks)
terraform state mv module.rds.aws_db_instance.postgres aws_db_instance.postgres
terraform state mv module.rds.aws_db_subnet_group.db aws_db_subnet_group.db
terraform state mv module.rds.aws_security_group.postgres_access aws_security_group.postgres_access

# Create new TF block and import new instance
terraform import aws_db_instance.postgres_db iiif-builder-prod-1
terraform apply

# update relevant secrets containing connstr + bounce services

# remove the old DB
terraform state rm aws_db_instance.postgres

# Re-module the rds resources
terraform state mv aws_db_instance.postgres_db module.rds.aws_db_instance.postgres
terraform state mv aws_db_subnet_group.db module.rds.aws_db_subnet_group.db
terraform state mv aws_security_group.postgres_access module.rds.aws_security_group.postgres_access
terraform apply
```