### PR TITLE
Bump ECS Terraform module versions

### DIFF
--- a/infrastructure/modules/ecs/private/main.tf
+++ b/infrastructure/modules/ecs/private/main.tf
@@ -1,18 +1,18 @@
 # Logging container using fluentbit
 module "log_router_container" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v2.6.3"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.12.2"
   namespace = local.full_name
 }
 
 module "log_router_permissions" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.6.3"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 # Create container definitions
 module "application_container_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.6.3"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.12.2"
   name   = local.full_name
 
   image         = var.docker_image
@@ -31,7 +31,7 @@ module "application_container_definition" {
 
 # Create task definition
 module "task_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.6.3"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.12.2"
 
   cpu    = var.cpu
   memory = var.memory
@@ -47,7 +47,7 @@ module "task_definition" {
 
 # secrets
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.6.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
   secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }

--- a/infrastructure/modules/ecs/web/main.tf
+++ b/infrastructure/modules/ecs/web/main.tf
@@ -1,18 +1,18 @@
 # Logging container using fluentbit
 module "log_router_container" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v2.6.3"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.12.2"
   namespace = local.full_name
 }
 
 module "log_router_permissions" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.6.3"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 # Create container definitions
 module "application_container_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.6.3"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.12.2"
   name   = local.full_name
 
   image         = var.docker_image
@@ -28,7 +28,7 @@ module "application_container_definition" {
 
 # Create task definition
 module "task_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.6.3"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.12.2"
 
   cpu    = var.cpu
   memory = var.memory
@@ -44,14 +44,14 @@ module "task_definition" {
 
 # secrets
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.6.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
   secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 # Create service
 module "service" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.6.3"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.12.2"
 
   cluster_arn  = var.ecs_cluster_arn
   service_name = local.full_name


### PR DESCRIPTION
Hello folks - someone (me) upgraded our logging cluster to Elasticsearch 8 without enough due diligence, and thus broke all the logging due to fluentbit sending a parameter that had been removed. This was [an easy fix](https://github.com/wellcomecollection/platform-infrastructure/pull/328/files) but does require a bump in the ECS terraform module version.

Because the versions here are quite old there are some other changes:
- Removal of an unused security group
- "addition" of a cloudwatch log group - this has actually just been moved around, so applying will give you a conflict error from AWS. It can be fixed by `terraform import`ing the existing resources into the new modules, at which point the plan will just show a change in retention policy for the logs.

Unfortunately I can't paste a plan here because it's too long for GitHub...