### PR TITLE
Add SNS topic and dashboard permissions to post to it

### DIFF
--- a/infrastructure/staging/.terraform.lock.hcl
+++ b/infrastructure/staging/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.8.0"
-  constraints = ">= 3.21.0"
+  constraints = "~> 4.8"
   hashes = [
     "h1:28IGImrkJquWBof3t9hNZfXrwBhqEr9rIKvPWLc1a10=",
+    "h1:T9Typ5V+dDwecG9USCLbW4oayxN3cxEGsG+OJzzjRgY=",
     "zh:16cbdbc03ad13358d12433e645e2ab5a615e3a3662a74e3c317267c9377713d8",
     "zh:1d813c5e6c21fe370652495e29f783db4e65037f913ff0d53d28515c36fbb70a",
     "zh:31ad8282e31d0fac62e96fc2321a68ad4b92ab90f560be5f875d1b01a493e491",

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -90,7 +90,7 @@ resource "aws_iam_role_policy" "dashboard_read_anno_bucket" {
 }
 
 resource "aws_iam_role_policy" "dashboard_publish_born_digital_bag_notifications_staging" {
-  name   = "dashboard-stage-publish-born-digital-bag-notifications-iiif-sns-topic"
+  name   = "dashboard-stage-publish-born-digital-bag-notifications-staging-iiif-sns-topic"
   role   = module.dashboard.task_role_name
   policy = data.aws_iam_policy_document.born_digital_bag_notifications_staging_publish.json
 }
@@ -186,8 +186,8 @@ resource "aws_iam_role_policy" "dashboardstgprd_read_anno_bucket" {
   policy = data.aws_iam_policy_document.annotations_read.json
 }
 
-resource "aws_iam_role_policy" "dashboardstgprd_publish_born_digital_bag_notifications_staging" {
-  name   = "dashboard-stageprd-publish-born-digital-bag-notifications-iiif-sns-topic"
+resource "aws_iam_role_policy" "dashboardstgprd_publish_born_digital_bag_notifications_prod" {
+  name   = "dashboard-stageprd-publish-born-digital-bag-notifications-prod-iiif-sns-topic"
   role   = module.dashboard_stageprod.task_role_name
-  policy = data.aws_iam_policy_document.born_digital_bag_notifications_staging_publish.json
+  policy = data.aws_iam_policy_document.born_digital_bag_notifications_prod_publish.json
 }

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -46,7 +46,8 @@ module "dashboard" {
   }
 
   env_vars = {
-    "ASPNETCORE_ENVIRONMENT" = "Staging"
+    "ASPNETCORE_ENVIRONMENT"        = "Staging"
+    "Storage__WorkflowMessageTopic" = data.aws_sns_topic.born_digital_bag_notifications_staging.arn
   }
 }
 
@@ -86,6 +87,12 @@ resource "aws_iam_role_policy" "dashboard_read_anno_bucket" {
   name   = "dashboard-stageprd-read-stage-anno-bucket"
   role   = module.dashboard.task_role_name
   policy = data.aws_iam_policy_document.annotations_read.json
+}
+
+resource "aws_iam_role_policy" "dashboard_publish_born_digital_bag_notifications_staging" {
+  name   = "dashboard-stage-publish-born-digital-bag-notifications-iiif-sns-topic"
+  role   = module.dashboard.task_role_name
+  policy = data.aws_iam_policy_document.born_digital_bag_notifications_staging_publish.json
 }
 
 # dashboard, staging hosted pointing at Prod storage
@@ -136,7 +143,8 @@ module "dashboard_stageprod" {
   }
 
   env_vars = {
-    "ASPNETCORE_ENVIRONMENT" = "Staging-Prod"
+    "ASPNETCORE_ENVIRONMENT"        = "Staging-Prod"
+    "Storage__WorkflowMessageTopic" = data.aws_sns_topic.born_digital_bag_notifications_staging.arn
   }
 }
 
@@ -176,4 +184,10 @@ resource "aws_iam_role_policy" "dashboardstgprd_read_anno_bucket" {
   name   = "dashboard-stageprd-read-stage-anno-bucket"
   role   = module.dashboard_stageprod.task_role_name
   policy = data.aws_iam_policy_document.annotations_read.json
+}
+
+resource "aws_iam_role_policy" "dashboardstgprd_publish_born_digital_bag_notifications_staging" {
+  name   = "dashboard-stageprd-publish-born-digital-bag-notifications-iiif-sns-topic"
+  role   = module.dashboard_stageprod.task_role_name
+  policy = data.aws_iam_policy_document.born_digital_bag_notifications_staging_publish.json
 }

--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -144,7 +144,7 @@ module "dashboard_stageprod" {
 
   env_vars = {
     "ASPNETCORE_ENVIRONMENT"        = "Staging-Prod"
-    "Storage__WorkflowMessageTopic" = data.aws_sns_topic.born_digital_bag_notifications_staging.arn
+    "Storage__WorkflowMessageTopic" = data.aws_sns_topic.born_digital_bag_notifications_prod.arn
   }
 }
 

--- a/infrastructure/staging/sns.tf
+++ b/infrastructure/staging/sns.tf
@@ -22,6 +22,12 @@ data "aws_sns_topic" "born_digital_bag_notifications_staging" {
   name = "born-digital-bag-notifications-staging"
 }
 
+data "aws_sns_topic" "born_digital_bag_notifications_prod" {
+  provider = aws.storage
+
+  name = "born-digital-bag-notifications-prod"
+}
+
 # access to SNS topic for iiif-test.wc.org cache-invalidation
 data "aws_iam_policy_document" "iiif_test_invalidate_cache_publish" {
   statement {
@@ -64,7 +70,7 @@ data "aws_iam_policy_document" "api_stage_invalidate_cache_publish" {
   }
 }
 
-# access to SNS topic for dashboard
+# access to SNS staging born digital notifications for stage dashboard
 data "aws_iam_policy_document" "born_digital_bag_notifications_staging_publish" {
   statement {
     actions = [
@@ -74,6 +80,20 @@ data "aws_iam_policy_document" "born_digital_bag_notifications_staging_publish" 
 
     resources = [
       data.aws_sns_topic.born_digital_bag_notifications_staging.arn
+    ]
+  }
+}
+
+# access to SNS staging born digital notifications for stageprd dashboard
+data "aws_iam_policy_document" "born_digital_bag_notifications_prod_publish" {
+  statement {
+    actions = [
+      "sns:Publish",
+      "sns:SendMessage",
+    ]
+
+    resources = [
+      data.aws_sns_topic.born_digital_bag_notifications_prod.arn
     ]
   }
 }

--- a/infrastructure/staging/sns.tf
+++ b/infrastructure/staging/sns.tf
@@ -16,6 +16,12 @@ data "aws_sns_topic" "api_stage_invalidate_cache" {
   name = "api-stage-cloudfront-invalidate"
 }
 
+data "aws_sns_topic" "born_digital_bag_notifications_staging" {
+  provider = aws.storage
+
+  name = "born-digital-bag-notifications-staging"
+}
+
 # access to SNS topic for iiif-test.wc.org cache-invalidation
 data "aws_iam_policy_document" "iiif_test_invalidate_cache_publish" {
   statement {
@@ -54,6 +60,20 @@ data "aws_iam_policy_document" "api_stage_invalidate_cache_publish" {
 
     resources = [
       data.aws_sns_topic.api_stage_invalidate_cache.arn
+    ]
+  }
+}
+
+# access to SNS topic for dashboard
+data "aws_iam_policy_document" "born_digital_bag_notifications_staging_publish" {
+  statement {
+    actions = [
+      "sns:Publish",
+      "sns:SendMessage",
+    ]
+
+    resources = [
+      data.aws_sns_topic.born_digital_bag_notifications.arn
     ]
   }
 }

--- a/infrastructure/staging/sns.tf
+++ b/infrastructure/staging/sns.tf
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "born_digital_bag_notifications_staging_publish" 
     ]
 
     resources = [
-      data.aws_sns_topic.born_digital_bag_notifications.arn
+      data.aws_sns_topic.born_digital_bag_notifications_staging.arn
     ]
   }
 }

--- a/infrastructure/staging/sqs.tf
+++ b/infrastructure/staging/sqs.tf
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "born_digital_notifications_staging_read_from_que
     ]
 
     resources = [
-      aws_sqs_queue.born_digital_notifications_staging_queue.arn
+      data.aws_sqs_queue.born_digital_notifications_staging_queue.arn
     ]
   }
 }
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "born_digital_notifications_prod_read_from_queue"
     ]
 
     resources = [
-      aws_sqs_queue.born_digital_notifications_prod_queue.arn
+      data.aws_sqs_queue.born_digital_notifications_prod_queue.arn
     ]
   }
 }

--- a/infrastructure/staging/sqs.tf
+++ b/infrastructure/staging/sqs.tf
@@ -40,3 +40,39 @@ resource "aws_sqs_queue_policy" "registered_bag_policy" {
 }
 POLICY
 }
+
+data "aws_sqs_queue" "born_digital_notifications_staging_queue" {
+  name = "born-digital-notifications-staging"
+}
+
+data "aws_sqs_queue" "born_digital_notifications_prod_queue" {
+  name = "born-digital-notifications-prod"
+}
+
+data "aws_iam_policy_document" "born_digital_notifications_staging_read_from_queue" {
+  statement {
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:ReceiveMessage",
+      "sqs:GetQueueUrl",
+    ]
+
+    resources = [
+      aws_sqs_queue.born_digital_notifications_staging_queue.arn
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "born_digital_notifications_prod_read_from_queue" {
+  statement {
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:ReceiveMessage",
+      "sqs:GetQueueUrl",
+    ]
+
+    resources = [
+      aws_sqs_queue.born_digital_notifications_prod_queue.arn
+    ]
+  }
+}

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -90,6 +90,12 @@ resource "aws_iam_role_policy" "workflowprocessor_publish_invalidate_api_topic" 
   policy = data.aws_iam_policy_document.api_stage_invalidate_cache_publish.json
 }
 
+resource "aws_iam_role_policy" "workflowprocessor_read_born_digital_notifications_staging_queue" {
+  name   = "workflowprocessor-read-born-digital-notifications-staging-queue"
+  role   = module.workflow_processor.task_role_name
+  policy = data.aws_iam_policy_document.born_digital_notifications_staging_read_from_queue.json
+}
+
 # workflow processor, staging pointing at prod storage
 module "workflow_processor_stageprod" {
   source = "../modules/ecs/private"
@@ -180,4 +186,10 @@ resource "aws_iam_role_policy" "workflowprocessorstgprd_publish_invalidate_api_t
   name   = "workflowprocessor-stageprd-publish-invalidate-api-sns-topic"
   role   = module.workflow_processor_stageprod.task_role_name
   policy = data.aws_iam_policy_document.api_stage_invalidate_cache_publish.json
+}
+
+resource "aws_iam_role_policy" "workflowprocessorstgprd_read_born_digital_notifications_prod_queue" {
+  name   = "workflowprocessorstgprd-read-born-digital-notifications-prod-queue"
+  role   = module.workflow_processor_stageprod.task_role_name
+  policy = data.aws_iam_policy_document.born_digital_notifications_prod_read_from_queue.json
 }


### PR DESCRIPTION
This adds the Storage bag notification topic as `data`, gives the dashboard its `arn` as an env var (to populate `StorageOptions`) and provides the policy for dashboard and dashboardstageprd to use.