### PR TITLE
Updates to our ECS-to-Elasticsearch logging

### DIFF
--- a/infrastructure/modules/ecs/private/main.tf
+++ b/infrastructure/modules/ecs/private/main.tf
@@ -1,18 +1,18 @@
 # Logging container using fluentbit
 module "log_router_container" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.12.2"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.13.1"
   namespace = local.full_name
 }
 
 module "log_router_permissions" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.13.1"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 # Create container definitions
 module "application_container_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.12.2"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.13.1"
   name   = local.full_name
 
   image         = var.docker_image
@@ -31,7 +31,7 @@ module "application_container_definition" {
 
 # Create task definition
 module "task_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.12.2"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.13.1"
 
   cpu    = var.cpu
   memory = var.memory
@@ -47,7 +47,7 @@ module "task_definition" {
 
 # secrets
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.13.1"
   secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }

--- a/infrastructure/modules/ecs/web/main.tf
+++ b/infrastructure/modules/ecs/web/main.tf
@@ -1,18 +1,18 @@
 # Logging container using fluentbit
 module "log_router_container" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.12.2"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.13.1"
   namespace = local.full_name
 }
 
 module "log_router_permissions" {
-  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
+  source    = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.13.1"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 # Create container definitions
 module "application_container_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.12.2"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.13.1"
   name   = local.full_name
 
   image         = var.docker_image
@@ -28,7 +28,7 @@ module "application_container_definition" {
 
 # Create task definition
 module "task_definition" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.12.2"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.13.1"
 
   cpu    = var.cpu
   memory = var.memory
@@ -44,14 +44,14 @@ module "task_definition" {
 
 # secrets
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.12.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.13.1"
   secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 # Create service
 module "service" {
-  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.12.2"
+  source = "git::https://github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.13.1"
 
   cluster_arn  = var.ecs_cluster_arn
   service_name = local.full_name


### PR DESCRIPTION
I've made [some changes](https://github.com/wellcomecollection/platform-infrastructure/pull/358) to the way the logging sidecar sends logs to Elasticsearch - primarily, this is that index rollover is handled by the cluster (with a data stream) rather than the sidecar. Until this is applied, your logs will still be available but I'm about to change the default data view in Kibana to the new one, so you'll have to look for them in the old view (`firelens-*`). 

Your plan should consist (per service) of a container image change, a new secret (`DATA_STREAM_NAME`) on the container, and permissions for that secret.