### PR TITLE
Update prod DB minor version

### DIFF
--- a/infrastructure/production/dashboard.tf
+++ b/infrastructure/production/dashboard.tf
@@ -47,8 +47,6 @@ module "dashboard" {
 
   env_vars = {
     "ASPNETCORE_ENVIRONMENT"                    = "Production"
-    "CacheInvalidation__InvalidateIIIFTopicArn" = data.aws_sns_topic.iiif_invalidate_cache.arn
-    "CacheInvalidation__InvalidateApiTopicArn"  = data.aws_sns_topic.api_invalidate_cache.arn
   }
 }
 
@@ -81,10 +79,4 @@ resource "aws_iam_role_policy" "dashboard_read_anno_bucket" {
   name   = "dashboard-read-anno-bucket"
   role   = module.dashboard.task_role_name
   policy = data.aws_iam_policy_document.annotations_read.json
-}
-
-resource "aws_iam_role_policy" "dashboard_publish_invalidate_topic" {
-  name   = "dashboard-publish-invalidate-sns-topic"
-  role   = module.dashboard.task_role_name
-  policy = data.aws_iam_policy_document.invalidate_cache_publish.json
 }

--- a/infrastructure/production/main.tf
+++ b/infrastructure/production/main.tf
@@ -9,10 +9,9 @@ module "rds" {
 
   name               = local.name
   environment        = local.environment
-  identifier_postfix = "-1"
   vpc_id             = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
-  db_engine_version = "12.10"
+  db_engine_version = "12.14"
   db_instance_class = "db.m4.large"
   db_storage        = 250
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets


### PR DESCRIPTION
Changes required by AWS as they were dropping supported minor version. The Postgres instance, db_subnet and security group are all within a module. To make the process of upgrading easier I moved the resources out of the module and back in temporarily. I'll include the commands + TF below to make it easier for when we need to do this again.

I also removed some changes for cache invalidation on production dashboard as these were not ready to be applied. I'll copy these to a separate PR that can sit until we're ready to apply.

Below are TF resources required before moving out of module (engine_version etc will differ):

```hcl
resource "aws_db_subnet_group" "db" {
  name       = "${local.name}-${local.environment}-db"
  subnet_ids = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
  tags       = {
    "Environment" = local.environment
    "Terraform"   = true
    "Name"        = "${local.name}-${local.environment}"
  }
}

resource "aws_security_group" "postgres_access" {
  description = "Access to Postgres"
  vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
  name        = "${local.name}-${local.environment}-postgres-access"

  ingress {
    protocol    = "tcp"
    from_port   = "5432"
    to_port     = "5432"
    cidr_blocks = [for s in data.aws_subnet.private_subnets : s.cidr_block]
  }

  tags =  {
    "Environment" = local.environment
    "Terraform"   = true
    "Name"        = "${local.name}-${local.environment}-postgress-access"
  }
}

data "aws_secretsmanager_secret_version" "admin_creds" {
  secret_id = "iiif-builder/production/db_admin"
}

resource "aws_db_instance" "postgres" {
  engine                     = "postgres"
  engine_version             = "12.10"
  identifier                 = "${local.name}-${local.environment}-1"
  instance_class             = "db.m4.large"
  allocated_storage          = 250
  username                   = jsondecode(data.aws_secretsmanager_secret_version.admin_creds.secret_string)["admin_username"]
  password                   = jsondecode(data.aws_secretsmanager_secret_version.admin_creds.secret_string)["admin_password"]
  storage_type               = "gp2"
  backup_retention_period    = "7"
  skip_final_snapshot        = true
  maintenance_window         = "sun:01:50-sun:02:20"
  backup_window              = "02:47-03:17"
  auto_minor_version_upgrade = false
  publicly_accessible        = false
  ca_cert_identifier         = "rds-ca-2019"

  vpc_security_group_ids = [
    data.terraform_remote_state.common.outputs.production_security_group_id,
    aws_security_group.postgres_access.id
  ]
  

  db_subnet_group_name = aws_db_subnet_group.db.name

  tags = {
    "Environment" = local.environment
    "Terraform"   = true
    "Name"        = "${local.name}-${local.environment}"
  }
}
```

Below are the required commands for moving resources out of module. This includes command to import `resources "aws_db_instance" "postgres_db"` temporarily

```bash
# move from module to main resources
terraform state mv module.rds.aws_db_instance.postgres aws_db_instance.postgres
terraform state mv module.rds.aws_db_subnet_group.db aws_db_subnet_group.db
terraform state mv module.rds.aws_security_group.postgres_access aws_security_group.postgres_access

# import 'new' instance
terraform import aws_db_instance.postgres_db <iiif-builder-prod>

# remove 'old' instance
terraform state rm aws_db_instance.postgres

# ..and back again
terraform state mv aws_db_instance.postgres_db module.rds.aws_db_instance.postgres
terraform state mv aws_db_subnet_group.db module.rds.aws_db_subnet_group.db
terraform state mv aws_security_group.postgres_access module.rds.aws_security_group.postgres_access
```