### PR TITLE
Enable performance_insights on RDS instances

### DIFF
--- a/infrastructure/modules/rds/main.tf
+++ b/infrastructure/modules/rds/main.tf
@@ -42,6 +42,8 @@ resource "aws_db_instance" "postgres" {
   auto_minor_version_upgrade = false
   publicly_accessible        = false
   ca_cert_identifier         = "rds-ca-2019"
+  
+  performance_insights_enabled = true
 
   vpc_security_group_ids = concat(
     var.db_security_group_ids,


### PR DESCRIPTION
## What does this change?

Enable `performance_insights` on both staging and production RDS instances.

## How to test

Once applied performance-insights will be visible via AWS console.

## How can we measure success?

Better visibility of expensive queries.

## Have we considered potential risks?

Low risk, adding additional monitoring to managed service. Overhead minimal. Can back out if there is an impact to performance.

