### PR TITLE
Update bastion AMI to use weco image

### DIFF
--- a/infrastructure/common/.terraform.lock.hcl
+++ b/infrastructure/common/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.19.0"
   constraints = "~> 4.8"
   hashes = [
+    "h1:5vufW94glXl3affobcZkp0TU10Ci+2y6R6kedH4eA6w=",
     "h1:Q1pATpL2UxF68UEvZ95Ocsf4HzdMuzuWu8SjV/8WR40=",
     "zh:22820bfa0065f583298015367f8dc015dffa5b19b76dbd78ecf5da8d7d599573",
     "zh:31a5c5fade4bd30dbc2b15f448cebb9ed527793c607e8687d3b2101bcf2c4471",
@@ -26,5 +27,16 @@ provider "registry.terraform.io/hashicorp/template" {
   constraints = ">= 2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "h1:LN84cu+BZpVRvYlCzrbPfCRDaIelSyEx/W9Iwwgbnn4=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
   ]
 }

--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -26,12 +26,21 @@ resource "aws_key_pair" "auth" {
   }
 }
 
+data "aws_ami" "bastion_host_ami" {
+  most_recent = true
+  owners      = ["self"]
+  filter {
+    name   = "name"
+    values = ["weco-amzn2-hvm-x86_64*"]
+  }
+}
+
 module "bastion" {
   source = "../modules/ec2/bastion"
 
   name          = "iiif-builder"
   instance_type = "t2.micro"
-  ami           = "ami-047bb4163c506cd98"
+  ami           = data.aws_ami.bastion_host_ami.id
 
   vpc_id                     = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
   subnets                    = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_public_subnets

--- a/infrastructure/modules/ec2/bastion/main.tf
+++ b/infrastructure/modules/ec2/bastion/main.tf
@@ -77,6 +77,8 @@ resource "aws_launch_configuration" "bastion" {
   instance_type        = var.instance_type
   iam_instance_profile = aws_iam_instance_profile.bastion.name
   key_name             = var.key_name
+  
+  associate_public_ip_address = true
 
   security_groups = concat(
     var.service_security_group_ids,


### PR DESCRIPTION
## What does this change?

Use wellcome provided AMI for bastion host. This updates "iiif-builder-bastion" as detailed on https://github.com/wellcomecollection/platform-infrastructure/issues/422

## Have we considered potential risks?

Low risk - bastion only used for accessing private resources from local machine. Access verified.

