### PR TITLE
Update staging DB - instance class, pg minor version and cert

### DIFF
--- a/infrastructure/modules/rds/main.tf
+++ b/infrastructure/modules/rds/main.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "postgres" {
   backup_window              = "02:47-03:17"
   auto_minor_version_upgrade = false
   publicly_accessible        = false
-  ca_cert_identifier         = "rds-ca-2019"
+  ca_cert_identifier         = var.db_cert_authority
   
   performance_insights_enabled = true
 

--- a/infrastructure/modules/rds/variables.tf
+++ b/infrastructure/modules/rds/variables.tf
@@ -58,3 +58,9 @@ variable "identifier_postfix" {
   description = "Postfix to add to DB name, useful when doing rolling updates"
   default     = ""
 }
+
+variable "db_cert_authority" {
+  type        = string
+  description = "Certificate authority identifier"
+  default     = "rds-ca-2019"
+}

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -10,8 +10,9 @@ module "rds" {
   environment = local.environment
   vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
-  db_engine_version = "12.14"
-  db_instance_class = "db.m4.large"
+  db_cert_authority = "rds-ca-rsa4096-g1"
+  db_engine_version = "12.18"
+  db_instance_class = "db.m6g.large"
   db_storage        = 250
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   db_ingress_cidrs  = [for s in data.aws_subnet.private_subnets : s.cidr_block]


### PR DESCRIPTION
## What does this change?

Upgrade staging database (changes made in last maintenance window, this change is reflecting those changes):
* Update instance from `db.m4.large` -> `db.m6g.large` as `db.m4.*` are approaching EOL
* Update pg minor version from `12.14` -> `12.18` as 12.14 is approaching EOL
* Update cert authority, previous is EOL later this year. 
  * Added cert authority as module arg as same module is used by Prod RDS which has yet to be upgraded.

## How to test

`iiif-stage.wellcomecollection.org` and `iiif-test.wellcomecollection.org` applications running.

## How can we measure success?

Stage and test environments running as before.

## Have we considered potential risks?

Low risk - failure to apply now will result in changes automatically applied by AWS at some point in the future. Minor version upgrade low risk.