### PR TITLE
Upgrade prod RDS to latest minor version

### DIFF
--- a/infrastructure/production/main.tf
+++ b/infrastructure/production/main.tf
@@ -11,12 +11,12 @@ module "rds" {
   environment = local.environment
   vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
-  identifier_postfix = "-1"
-  db_engine_version = "12.14"
+  db_engine_version = "12.18"
   db_instance_class = "db.m6g.large"
   db_storage        = 250
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   db_ingress_cidrs  = [for s in data.aws_subnet.private_subnets : s.cidr_block]
+  db_cert_authority = "rds-ca-rsa2048-g1"
 
   db_security_group_ids = [
     data.terraform_remote_state.common.outputs.production_security_group_id,


### PR DESCRIPTION
Work done outside of TF

## What does this change?

Upgrade production database (changes made manually to avoid downtime, this change reflects changes made in AWS):
* Update pg minor version from `12.14` -> `12.18` as 12.14 is approaching EOL
* Update cert authority, previous is EOL later this year. 

## How to test

`iiif.wellcomecollection.org` applications working.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Changes made in AWS while monitoring services. Incumbent database will be kept for short period to ease rolling back (requires updating connection-string in secret and restarting services).

