### PR TITLE
Add alarms for prod rds

### DIFF
--- a/infrastructure/modules/rds/outputs.tf
+++ b/infrastructure/modules/rds/outputs.tf
@@ -1,3 +1,7 @@
 output "db_address" {
   value = aws_db_instance.postgres.address
 }
+
+output "db_name" {
+  value = aws_db_instance.postgres.identifier
+}

--- a/infrastructure/production/cloudwatch-alarm.tf
+++ b/infrastructure/production/cloudwatch-alarm.tf
@@ -1,0 +1,41 @@
+resource "aws_cloudwatch_metric_alarm" "rds_high_connections" {
+  alarm_name         = "${local.full_name}_rds_connections"
+  alarm_description  = "IIIF Builder RDS high connection count"
+  evaluation_periods = 2
+  period             = 60
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  statistic           = "Maximum"
+  threshold           = 50 # normally sit around 10
+  dimensions = {
+    DBInstanceIdentifier = module.rds.db_name
+  }
+
+  ok_actions    = [data.terraform_remote_state.dlcs.outputs.cloudwatch_alarm_topic_arn]
+  alarm_actions = [data.terraform_remote_state.dlcs.outputs.cloudwatch_alarm_topic_arn]
+
+  treat_missing_data = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_dbload" {
+  alarm_name         = "${local.full_name}_dbload"
+  alarm_description  = "IIIF Builder RDS high DBLoad"
+  evaluation_periods = 2
+  period             = 60
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "DBLoad"
+  namespace           = "AWS/RDS"
+  statistic           = "Maximum"
+  threshold           = 60 # normally sit around 3
+  dimensions = {
+    DBInstanceIdentifier = module.rds.db_name
+  }
+
+  ok_actions    = [data.terraform_remote_state.dlcs.outputs.cloudwatch_alarm_topic_arn]
+  alarm_actions = [data.terraform_remote_state.dlcs.outputs.cloudwatch_alarm_topic_arn]
+
+  treat_missing_data = "notBreaching"
+}

--- a/infrastructure/production/data.tf
+++ b/infrastructure/production/data.tf
@@ -17,14 +17,27 @@ data "terraform_remote_state" "platform_infra" {
   backend = "s3"
 
   config = {
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/aws-account-infrastructure/digirati.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/aws-account-infrastructure/digirati.tfstate"
+    region = "eu-west-1"
 
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
 
     profile = "wellcome-az"
+  }
+}
+
+# remote-state for DLCS
+data "terraform_remote_state" "dlcs" {
+  backend = "s3"
+
+  config = {
+    bucket = "dlcs-remote-state"
+    key    = "terraform.tfstate"
+    region = "eu-west-1"
+
+    profile = "wcdev"
   }
 }


### PR DESCRIPTION
## What does this change?

Adds alarm to monitor production RDS instance. Will raise alarm if `DBLoad` or `DatabaseConnections` is higher than expected.

## How to test

Use cloudwatch to verify metrics are showing.

When applied will get a slack notification of `State moved from INSUFFICIENT_DATA to OK`

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

