### PR TITLE
Update stage-prod to use temporary DLCS

### DIFF
--- a/infrastructure/staging/dashboard.tf
+++ b/infrastructure/staging/dashboard.tf
@@ -162,14 +162,14 @@ module "dashboard_stageprod" {
     Dlcs__ApiSecret                       = "iiif-builder/stage-prd/dlcs-apisecret"
   }
 
-  env_vars = {
+  env_vars = merge(local.stage_prod_temp_envvars, {
     "ASPNETCORE_ENVIRONMENT"                    = "Staging-Prod"
     "ASPNETCORE_URLS"                           = "http://*:80"
     "CacheInvalidation__InvalidateIIIFTopicArn" = data.aws_sns_topic.iiif_test_invalidate_cache.arn
     "CacheInvalidation__InvalidateApiTopicArn"  = data.aws_sns_topic.api_stage_invalidate_cache.arn
     "TZ"                                        = "Europe/London"
-    "LANG"                                      = "en_GB.UTF8"    
-  }
+    "LANG"                                      = "en_GB.UTF8"
+  })
 }
 
 module "dashboard_stageprod_scaling" {

--- a/infrastructure/staging/iiif-builder.tf
+++ b/infrastructure/staging/iiif-builder.tf
@@ -134,13 +134,13 @@ module "iiif_builder_stageprod" {
     Dlcs__ApiSecret                       = "iiif-builder/stage-prd/dlcs-apisecret"
   }
 
-  env_vars = {
+  env_vars = merge(local.stage_prod_temp_envvars, {
     "ASPNETCORE_ENVIRONMENT"                  = "Staging-Prod"
     "ASPNETCORE_URLS"                         = "http://*:80"
     "ASPNETCORE_HTTP_PORTS"                   = "80"
     "FeatureManagement__TextServices"         = "False"
     "FeatureManagement__PresentationServices" = "True"
-  }
+  })
 }
 
 module "iiif_builder_stageprod_scaling" {

--- a/infrastructure/staging/job-processor.tf
+++ b/infrastructure/staging/job-processor.tf
@@ -93,11 +93,11 @@ module "job_processor_stageprod" {
     Dlcs__ApiSecret                       = "iiif-builder/stage-prd/dlcs-apisecret"
   }
 
-  env_vars = {    
+  env_vars = merge(local.stage_prod_temp_envvars, {
     "ASPNETCORE_ENVIRONMENT" = "Staging-Prod"
     "ASPNETCORE_URLS"        = "http://*:80"
     "ASPNETCORE_HTTP_PORTS"  = "80"
-  }
+  })
 
   healthcheck = {
     command     = ["CMD-SHELL", "curl -f http://localhost:80/management/healthcheck"]

--- a/infrastructure/staging/variables.tf
+++ b/infrastructure/staging/variables.tf
@@ -15,6 +15,13 @@ locals {
   }
 
   account_id = data.aws_caller_identity.current.account_id
+
+  stage_prod_temp_envvars = {
+    Dlcs__SkeletonNamedQueryTemplate  = "https://porch.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}"
+    Dlcs__SingleAssetManifestTemplate = "https://porch.dlcs.io/iiif-manifest/wellcome/{0}/{1}"
+    Dlcs__ApiEntryPoint               = "https://papi.dlcs.io/"
+    Dlcs__InternalResourceEntryPoint  = "https://porch.dlcs.io/"
+  }
 }
 
 variable "region" {

--- a/infrastructure/staging/workflow-processor.tf
+++ b/infrastructure/staging/workflow-processor.tf
@@ -132,14 +132,14 @@ module "workflow_processor_stageprod" {
     Dlcs__ApiSecret                       = "iiif-builder/stage-prd/dlcs-apisecret"
   }
 
-  env_vars = {
+  env_vars = merge(local.stage_prod_temp_envvars, {
     "ASPNETCORE_ENVIRONMENT"                    = "Staging-Prod"
     "ASPNETCORE_URLS"                           = "http://*:80"
     "ASPNETCORE_HTTP_PORTS"                     = "80"
     "CacheInvalidation__InvalidateIIIFTopicArn" = data.aws_sns_topic.iiif_test_invalidate_cache.arn
     "CacheInvalidation__InvalidateApiTopicArn"  = data.aws_sns_topic.api_stage_invalidate_cache.arn
     "Dds__WorkflowMessagePoll"                  = "False"
-  }
+  })
 
   healthcheck = {
     command     = ["CMD-SHELL", "curl -f http://localhost:80/management/healthcheck"]


### PR DESCRIPTION
For testing changes to ingest process - temporary

> [!NOTE]
> A note on hostnames for DLCS. The `p` prefix is for parallel, so `api.` becomes `papi.`, `engine.` -> `pengine.`, Orchestrator can't be on apex so `orch.` -> `porch.`. Not particularly graceful but these are only transient.

## What does this change?

Update appSettings for stage-prod (aka test) environment to use temporary "parallel" dlcs. 

Change is temporary, used to confirm engine changes to https://github.com/dlcs/protagonist/releases/tag/v1.11.0

## How to test

Queue small work in dashboard and follow process through processors - confirm final item is ingested into 'new' dlcs. Once e2e is confirmed we can progress with full testing.

## How can we measure success?

Real testing is of DLCS upgrade, these changes are a means to do that.

## Have we considered potential risks?

Temporary change to non production environment, any issues we can easily rollback.