### PR TITLE
Schedule non-prod RDS upgrade

### DIFF
--- a/infrastructure/modules/rds/main.tf
+++ b/infrastructure/modules/rds/main.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "postgres" {
   storage_type               = "gp2"
   backup_retention_period    = "7"
   skip_final_snapshot        = true
-  maintenance_window         = "sun:01:50-sun:02:20"
+  maintenance_window         = var.maintenance_window
   backup_window              = "02:47-03:17"
   auto_minor_version_upgrade = false
   publicly_accessible        = false

--- a/infrastructure/modules/rds/main.tf
+++ b/infrastructure/modules/rds/main.tf
@@ -42,6 +42,8 @@ resource "aws_db_instance" "postgres" {
   auto_minor_version_upgrade = false
   publicly_accessible        = false
   ca_cert_identifier         = var.db_cert_authority
+
+  allow_major_version_upgrade = var.allow_major_version_upgrade
   
   deletion_protection          = var.deletion_protection
   performance_insights_enabled = true

--- a/infrastructure/modules/rds/variables.tf
+++ b/infrastructure/modules/rds/variables.tf
@@ -70,3 +70,8 @@ variable "deletion_protection" {
   description = "Whether delete protection should be enabled on RDS instance"
   default     = true
 }
+
+variable "maintenance_window" {
+  description = "The window to perform maintenance in"
+  default     = "sun:01:50-sun:02:20"
+}

--- a/infrastructure/modules/rds/variables.tf
+++ b/infrastructure/modules/rds/variables.tf
@@ -75,3 +75,8 @@ variable "maintenance_window" {
   description = "The window to perform maintenance in"
   default     = "sun:01:50-sun:02:20"
 }
+
+variable "allow_major_version_upgrade" {
+  description = "Indicates that major version upgrades are allowed."
+  default     = false
+}

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -11,11 +11,13 @@ module "rds" {
   vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
   db_cert_authority = "rds-ca-rsa4096-g1"
-  db_engine_version = "13.18"
+  db_engine_version = "14.21"
   db_instance_class = "db.m6g.large"
   db_storage        = 250
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   db_ingress_cidrs  = [for s in data.aws_subnet.private_subnets : s.cidr_block]
+
+  maintenance_window = "thu:04:50-thu:05:20"
 
   db_security_group_ids = [
     data.terraform_remote_state.common.outputs.staging_security_group_id,

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -17,7 +17,8 @@ module "rds" {
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets
   db_ingress_cidrs  = [for s in data.aws_subnet.private_subnets : s.cidr_block]
 
-  maintenance_window = "thu:04:50-thu:05:20"
+  maintenance_window          = "thu:04:50-thu:05:20"
+  allow_major_version_upgrade = true
 
   db_security_group_ids = [
     data.terraform_remote_state.common.outputs.staging_security_group_id,


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->

Set iiif-builder-stage RDS instance maintenance window to be Thursday (tomorrow) and schedule update from Postgres 13 to latest available Postgres 14.

Also updated RDS module to allow `maintenance_window` to be set by caller as it's shared between prod + non-prod.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Verify test and staging iiif-builder environments still working as expected.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

No issues with test/staging environment.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

Low risk, RDS instance is for non-production environments. 

Maintenance window is `04:50-05:20`, backup will have been taken shortly before this between `02:47-03:17`

