### PR TITLE
Update production DB to postgres 14

### DIFF
--- a/infrastructure/production/main.tf
+++ b/infrastructure/production/main.tf
@@ -11,9 +11,7 @@ module "rds" {
   environment = local.environment
   vpc_id      = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_id
 
-  identifier_postfix = "-1"
-
-  db_engine_version = "13.18"
+  db_engine_version = "14.21"
   db_instance_class = "db.m6g.large"
   db_storage        = 250
   db_subnets        = data.terraform_remote_state.platform_infra.outputs.digirati_vpc_private_subnets


### PR DESCRIPTION
## What does this change?

Set iiif-builder-prod RDS instance to Postgres 14 (was 13 but this is now out of support).

Most of this work was done outside of Terraform. Final step was to run

```
terraform state rm
terraform state import
```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->

## How to test

Verify Production iiif-builder environments still working as expected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

No database related issues for iiif-builder production.

## Have we considered potential risks?

PR #78 was doing this change in staging, which was successful. Database use is identical between these environments.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

